### PR TITLE
🔍 Use comswasm-check for check contract

### DIFF
--- a/Makefile.toml
+++ b/Makefile.toml
@@ -86,12 +86,12 @@ env = { RUSTFLAGS = "-C link-arg=-s" }
 
 [tasks.check_contracts]
 dependencies = ["wasm"]
-install_crate = { crate_name = "cw-check-contract" }
+install_crate = { crate_name = "cosmwasm-check" }
 script = '''
 for W in ./target/wasm32-unknown-unknown/release/*.wasm
 do
   echo -n "🔎 Checking `basename $W`... "
-  cw-check-contract $W
+  cosmwasm-check $W
 done
 '''
 

--- a/Makefile.toml
+++ b/Makefile.toml
@@ -88,11 +88,7 @@ env = { RUSTFLAGS = "-C link-arg=-s" }
 dependencies = ["wasm"]
 install_crate = { crate_name = "cosmwasm-check" }
 script = '''
-for W in ./target/wasm32-unknown-unknown/release/*.wasm
-do
-  echo -n "🔎 Checking `basename $W`... "
-  cosmwasm-check $W
-done
+cosmwasm-check ./target/wasm32-unknown-unknown/release/*.wasm
 '''
 
 [config]


### PR DESCRIPTION
Following @webmaster128 [comment](https://github.com/okp4/contracts/pull/12#issuecomment-1245452311) (thanks 😉), I've removed the experimental cw-check-contract crate and replaced by [cosmwasm-check](https://crates.io/crates/cosmwasm-check) crate. 