### PR TITLE
📚 Trigger update docs repository

### DIFF
--- a/.github/workflows/notify-release.yml
+++ b/.github/workflows/notify-release.yml
@@ -20,3 +20,23 @@ jobs:
               "username": "Bot Anik",
               "content": "🚨 A new version of @${{ github.repository }} ${{ github.event.release.tag_name }} has been released! 🎉\n\n👉 Changelog: https://github.com/${{ github.repository }}/releases/tag/${{ github.event.release.tag_name }}\n👉 Official repo: https://github.com/${{ github.repository }}"
             }
+
+  update-docs:
+    runs-on: ubuntu-22.04
+    steps:
+      - name: Update docs repository
+        uses: fjogeleit/http-request-action@v1
+        with:
+          url: 'https://api.github.com/repos/okp4/docs/actions/workflows/update-versioned-docs/dispatches'
+          method: 'POST'
+          customHeaders: '{"Accept": "application/vnd.github+json", "Authorization": "Bearer ${{ secrets.OKP4_TOKEN }}"}'
+          data: |-
+            {
+              "ref": "main",
+              "inputs": {
+                "version": "${{ github.event.release.tag_name }}",
+                "repository": "${{github.repository}}",
+                "section": "contracts",
+                "docs_directory": "docs/*"
+              }
+            }


### PR DESCRIPTION
Like https://github.com/okp4/okp4d/pull/200, trigger docs repository to update the smart contract documentation on new release version. 

🔗 See https://github.com/okp4/docs/pull/136.