### PR TITLE
📖 Trigger publish draft docs

### DIFF
--- a/.github/workflows/notify-release.yml
+++ b/.github/workflows/notify-release.yml
@@ -27,7 +27,7 @@ jobs:
       - name: Update docs repository
         uses: fjogeleit/http-request-action@v1
         with:
-          url: 'https://api.github.com/repos/okp4/docs/actions/workflows/update-versioned-docs/dispatches'
+          url: 'https://api.github.com/repos/okp4/docs/actions/workflows/39152549/dispatches'
           method: 'POST'
           customHeaders: '{"Accept": "application/vnd.github+json", "Authorization": "Bearer ${{ secrets.OKP4_TOKEN }}"}'
           data: |-

--- a/.github/workflows/update-draft-docs.yml
+++ b/.github/workflows/update-draft-docs.yml
@@ -1,0 +1,27 @@
+name: update-draft-docs
+
+on:
+  push:
+    branches: [ main ]
+
+jobs:
+  update-docs:
+    runs-on: ubuntu-22.04
+    steps:
+      - name: Update draft docs repository
+        uses: fjogeleit/http-request-action@v1
+        with:
+          url: 'https://api.github.com/repos/okp4/docs/actions/workflows/39152549/dispatches'
+          method: 'POST'
+          customHeaders: '{"Accept": "application/vnd.github+json", "Authorization": "Bearer ${{ secrets.OKP4_TOKEN }}"}'
+          data: |-
+            {
+              "ref": "main",
+              "inputs": {
+                "version": "main",
+                "repository": "${{github.repository}}",
+                "section": "contracts",
+                "docs_directory": "docs/*"
+                "draft": "true"
+              }
+            }


### PR DESCRIPTION
- Same as https://github.com/okp4/okp4d/pull/255, a PR to add a workflow that will trigger the docs update on the docs repository only for the next section of the doc each time there is a commit on main. 

- Also fix the trigger workflow ID. 