### PR TITLE
🧪 Add mock logic querier

### DIFF
--- a/contracts/cw-logic-sample/src/contract.rs
+++ b/contracts/cw-logic-sample/src/contract.rs
@@ -84,6 +84,6 @@ mod tests {
         )
         .unwrap();
         let value: AskResponse = from_binary(&res).unwrap();
-        assert_eq!(true, value.answer.unwrap().success);
+        assert!(value.answer.unwrap().success);
     }
 }

--- a/contracts/cw-logic-sample/src/contract.rs
+++ b/contracts/cw-logic-sample/src/contract.rs
@@ -14,7 +14,7 @@ const CONTRACT_VERSION: &str = env!("CARGO_PKG_VERSION");
 
 #[cfg_attr(not(feature = "library"), entry_point)]
 pub fn instantiate(
-    deps: DepsMut<LogicCustomQuery>,
+    deps: DepsMut<'_, LogicCustomQuery>,
     _env: Env,
     info: MessageInfo,
     msg: InstantiateMsg,
@@ -31,7 +31,7 @@ pub fn instantiate(
 }
 
 #[cfg_attr(not(feature = "library"), entry_point)]
-pub fn query(deps: Deps<LogicCustomQuery>, _env: Env, msg: QueryMsg) -> StdResult<Binary> {
+pub fn query(deps: Deps<'_, LogicCustomQuery>, _env: Env, msg: QueryMsg) -> StdResult<Binary> {
     match msg {
         QueryMsg::Ask { query } => to_binary(&query::ask(deps, query)?),
     }
@@ -40,7 +40,7 @@ pub fn query(deps: Deps<LogicCustomQuery>, _env: Env, msg: QueryMsg) -> StdResul
 pub mod query {
     use super::*;
 
-    pub fn ask(deps: Deps<LogicCustomQuery>, query: String) -> StdResult<AskResponse> {
+    pub fn ask(deps: Deps<'_, LogicCustomQuery>, query: String) -> StdResult<AskResponse> {
         let state = STATE.load(deps.storage)?;
 
         let req = LogicCustomQuery::Ask {
@@ -55,10 +55,9 @@ pub mod query {
 
 #[cfg(test)]
 mod tests {
-    use std::marker::PhantomData;
     use super::*;
-    use cosmwasm_std::testing::{mock_dependencies, mock_env, mock_info, MockApi, MockQuerier, MockStorage};
-    use cosmwasm_std::{Coin, coins, from_binary, OwnedDeps};
+    use cosmwasm_std::testing::{mock_env, mock_info};
+    use cosmwasm_std::{Coin, coins, from_binary};
     use logic_bindings::testing::mock::mock_dependencies_with_logic_and_balance;
 
 

--- a/contracts/cw-logic-sample/src/contract.rs
+++ b/contracts/cw-logic-sample/src/contract.rs
@@ -57,13 +57,13 @@ pub mod query {
 mod tests {
     use super::*;
     use cosmwasm_std::testing::{mock_env, mock_info};
-    use cosmwasm_std::{Coin, coins, from_binary};
+    use cosmwasm_std::{coins, from_binary, Coin};
     use logic_bindings::testing::mock::mock_dependencies_with_logic_and_balance;
-
 
     #[test]
     fn proper_initialization() {
-        let mut deps = mock_dependencies_with_logic_and_balance(&[Coin::new(10000, "uknow".to_string())]);
+        let mut deps =
+            mock_dependencies_with_logic_and_balance(&[Coin::new(10000, "uknow".to_string())]);
 
         let msg = InstantiateMsg {
             program: "bank_balances_has_coin(A, D, V, S) :- bank_balances(A, R), member(D-V, R), compare(>, V, S).".to_string(),
@@ -75,7 +75,14 @@ mod tests {
         assert_eq!(0, res.messages.len());
 
         // it worked, let's check if logic querier is called to answer to the `Ask` query.
-        let res = query(deps.as_ref(), mock_env(), QueryMsg::Ask { query: "".to_string() }).unwrap();
+        let res = query(
+            deps.as_ref(),
+            mock_env(),
+            QueryMsg::Ask {
+                query: "".to_string(),
+            },
+        )
+        .unwrap();
         let value: AskResponse = from_binary(&res).unwrap();
         assert_eq!(true, value.answer.unwrap().success);
     }

--- a/contracts/cw-logic-sample/src/lib.rs
+++ b/contracts/cw-logic-sample/src/lib.rs
@@ -1,13 +1,13 @@
 #![forbid(unsafe_code)]
 #![deny(
-warnings,
-rust_2018_idioms,
-trivial_casts,
-trivial_numeric_casts,
-unused_lifetimes,
-unused_import_braces,
-unused_qualifications,
-unused_qualifications
+    warnings,
+    rust_2018_idioms,
+    trivial_casts,
+    trivial_numeric_casts,
+    unused_lifetimes,
+    unused_import_braces,
+    unused_qualifications,
+    unused_qualifications
 )]
 
 pub mod contract;

--- a/contracts/cw-logic-sample/src/lib.rs
+++ b/contracts/cw-logic-sample/src/lib.rs
@@ -1,3 +1,15 @@
+#![forbid(unsafe_code)]
+#![deny(
+warnings,
+rust_2018_idioms,
+trivial_casts,
+trivial_numeric_casts,
+unused_lifetimes,
+unused_import_braces,
+unused_qualifications,
+unused_qualifications
+)]
+
 pub mod contract;
 mod error;
 pub mod msg;

--- a/contracts/cw-logic-sample/src/msg.rs
+++ b/contracts/cw-logic-sample/src/msg.rs
@@ -1,4 +1,5 @@
 use cosmwasm_schema::{cw_serde, QueryResponses};
+#[allow(unused_imports)]
 use logic_bindings::AskResponse;
 
 /// Instantiate messages

--- a/contracts/cw-logic-sample/src/state.rs
+++ b/contracts/cw-logic-sample/src/state.rs
@@ -8,4 +8,4 @@ pub struct State {
     pub program: String,
 }
 
-pub const STATE: Item<State> = Item::new("state");
+pub const STATE: Item<'_, State> = Item::new("state");

--- a/contracts/cw-template/src/contract.rs
+++ b/contracts/cw-template/src/contract.rs
@@ -13,7 +13,7 @@ const CONTRACT_VERSION: &str = env!("CARGO_PKG_VERSION");
 
 #[cfg_attr(not(feature = "library"), entry_point)]
 pub fn instantiate(
-    deps: DepsMut,
+    deps: DepsMut<'_>,
     _env: Env,
     info: MessageInfo,
     msg: InstantiateMsg,
@@ -33,7 +33,7 @@ pub fn instantiate(
 
 #[cfg_attr(not(feature = "library"), entry_point)]
 pub fn execute(
-    deps: DepsMut,
+    deps: DepsMut<'_>,
     _env: Env,
     info: MessageInfo,
     msg: ExecuteMsg,
@@ -47,7 +47,7 @@ pub fn execute(
 pub mod execute {
     use super::*;
 
-    pub fn increment(deps: DepsMut) -> Result<Response, ContractError> {
+    pub fn increment(deps: DepsMut<'_>) -> Result<Response, ContractError> {
         STATE.update(deps.storage, |mut state| -> Result<_, ContractError> {
             state.count += 1;
             Ok(state)
@@ -56,7 +56,7 @@ pub mod execute {
         Ok(Response::new().add_attribute("action", "increment"))
     }
 
-    pub fn reset(deps: DepsMut, info: MessageInfo, count: i32) -> Result<Response, ContractError> {
+    pub fn reset(deps: DepsMut<'_>, info: MessageInfo, count: i32) -> Result<Response, ContractError> {
         STATE.update(deps.storage, |mut state| -> Result<_, ContractError> {
             if info.sender != state.owner {
                 return Err(ContractError::Unauthorized {});
@@ -69,7 +69,7 @@ pub mod execute {
 }
 
 #[cfg_attr(not(feature = "library"), entry_point)]
-pub fn query(deps: Deps, _env: Env, msg: QueryMsg) -> StdResult<Binary> {
+pub fn query(deps: Deps<'_>, _env: Env, msg: QueryMsg) -> StdResult<Binary> {
     match msg {
         QueryMsg::GetCount {} => to_binary(&query::count(deps)?),
     }
@@ -78,7 +78,7 @@ pub fn query(deps: Deps, _env: Env, msg: QueryMsg) -> StdResult<Binary> {
 pub mod query {
     use super::*;
 
-    pub fn count(deps: Deps) -> StdResult<GetCountResponse> {
+    pub fn count(deps: Deps<'_>) -> StdResult<GetCountResponse> {
         let state = STATE.load(deps.storage)?;
         Ok(GetCountResponse { count: state.count })
     }

--- a/contracts/cw-template/src/contract.rs
+++ b/contracts/cw-template/src/contract.rs
@@ -56,7 +56,11 @@ pub mod execute {
         Ok(Response::new().add_attribute("action", "increment"))
     }
 
-    pub fn reset(deps: DepsMut<'_>, info: MessageInfo, count: i32) -> Result<Response, ContractError> {
+    pub fn reset(
+        deps: DepsMut<'_>,
+        info: MessageInfo,
+        count: i32,
+    ) -> Result<Response, ContractError> {
         STATE.update(deps.storage, |mut state| -> Result<_, ContractError> {
             if info.sender != state.owner {
                 return Err(ContractError::Unauthorized {});

--- a/contracts/cw-template/src/lib.rs
+++ b/contracts/cw-template/src/lib.rs
@@ -1,13 +1,13 @@
 #![forbid(unsafe_code)]
 #![deny(
-warnings,
-rust_2018_idioms,
-trivial_casts,
-trivial_numeric_casts,
-unused_lifetimes,
-unused_import_braces,
-unused_qualifications,
-unused_qualifications
+    warnings,
+    rust_2018_idioms,
+    trivial_casts,
+    trivial_numeric_casts,
+    unused_lifetimes,
+    unused_import_braces,
+    unused_qualifications,
+    unused_qualifications
 )]
 
 pub mod contract;

--- a/contracts/cw-template/src/lib.rs
+++ b/contracts/cw-template/src/lib.rs
@@ -1,3 +1,15 @@
+#![forbid(unsafe_code)]
+#![deny(
+warnings,
+rust_2018_idioms,
+trivial_casts,
+trivial_numeric_casts,
+unused_lifetimes,
+unused_import_braces,
+unused_qualifications,
+unused_qualifications
+)]
+
 pub mod contract;
 mod error;
 pub mod helpers;

--- a/contracts/cw-template/src/state.rs
+++ b/contracts/cw-template/src/state.rs
@@ -10,4 +10,4 @@ pub struct State {
     pub owner: Addr,
 }
 
-pub const STATE: Item<State> = Item::new("state");
+pub const STATE: Item<'_, State> = Item::new("state");

--- a/packages/logic-bindings/src/lib.rs
+++ b/packages/logic-bindings/src/lib.rs
@@ -1,13 +1,13 @@
 #![forbid(unsafe_code)]
 #![deny(
-warnings,
-rust_2018_idioms,
-trivial_casts,
-trivial_numeric_casts,
-unused_lifetimes,
-unused_import_braces,
-unused_qualifications,
-unused_qualifications
+    warnings,
+    rust_2018_idioms,
+    trivial_casts,
+    trivial_numeric_casts,
+    unused_lifetimes,
+    unused_import_braces,
+    unused_qualifications,
+    unused_qualifications
 )]
 
 mod query;

--- a/packages/logic-bindings/src/lib.rs
+++ b/packages/logic-bindings/src/lib.rs
@@ -1,3 +1,15 @@
+#![forbid(unsafe_code)]
+#![deny(
+warnings,
+rust_2018_idioms,
+trivial_casts,
+trivial_numeric_casts,
+unused_lifetimes,
+unused_import_braces,
+unused_qualifications,
+unused_qualifications
+)]
+
 mod query;
 
 pub use query::{Answer, AskResponse, LogicCustomQuery, Result, Substitution, Term};

--- a/packages/logic-bindings/src/testing/mock.rs
+++ b/packages/logic-bindings/src/testing/mock.rs
@@ -1,13 +1,14 @@
-use std::marker::PhantomData;
-use cosmwasm_std::{Coin, OwnedDeps, QuerierResult, SystemResult, to_binary};
-use cosmwasm_std::testing::{MOCK_CONTRACT_ADDR, MockApi, MockQuerier, MockStorage};
 use crate::{Answer, AskResponse, LogicCustomQuery, Substitution, Term};
+use cosmwasm_std::testing::{MockApi, MockQuerier, MockStorage, MOCK_CONTRACT_ADDR};
+use cosmwasm_std::{to_binary, Coin, OwnedDeps, QuerierResult, SystemResult};
+use std::marker::PhantomData;
 
 /// Creates all external requirements that can be injected for unit tests.
 ///
 /// It sets the given balance for the contract itself, nothing else and set the custom default logic
 /// querier handler.
-pub fn mock_dependencies_with_logic_and_balance( contract_balance: &[Coin],
+pub fn mock_dependencies_with_logic_and_balance(
+    contract_balance: &[Coin],
 ) -> OwnedDeps<MockStorage, MockApi, MockQuerier<LogicCustomQuery>, LogicCustomQuery> {
     mock_dependencies_with_logic_and_balances(&[(MOCK_CONTRACT_ADDR, contract_balance)])
 }
@@ -16,14 +17,15 @@ pub fn mock_dependencies_with_logic_and_balance( contract_balance: &[Coin],
 ///
 /// Set the logic querier mock handler.
 /// Sets all balances provided (you must explicitly set contract balance if desired).
-pub fn mock_dependencies_with_logic_and_balances(balances: &[(&str, &[Coin])]) -> OwnedDeps<MockStorage, MockApi, MockQuerier<LogicCustomQuery>, LogicCustomQuery> {
+pub fn mock_dependencies_with_logic_and_balances(
+    balances: &[(&str, &[Coin])],
+) -> OwnedDeps<MockStorage, MockApi, MockQuerier<LogicCustomQuery>, LogicCustomQuery> {
     OwnedDeps {
         storage: MockStorage::default(),
         api: MockApi::default(),
         querier: MockLogicQuerier::new(LogicQuerier::default(), balances),
         custom_query_type: PhantomData,
     }
-
 }
 
 trait MockLogicQuerier {
@@ -51,8 +53,8 @@ impl LogicQuerier {
 
     #[allow(dead_code)]
     fn update_handler<LH: 'static>(&mut self, handler: LH)
-        where
-            LH: Fn(&LogicCustomQuery) -> QuerierResult,
+    where
+        LH: Fn(&LogicCustomQuery) -> QuerierResult,
     {
         self.handler = Box::from(handler)
     }
@@ -69,16 +71,15 @@ impl Default for LogicQuerier {
                         success: true,
                         has_more: false,
                         variables: vec!["foo".to_string()],
-                        results: vec![
-                            crate::Result {
-                                substitutions: vec![Substitution {
-                                    variable: "foo".to_string(),
-                                    term: Term {
-                                        name: "bar".to_string(),
-                                        arguments: vec![]
-                                    }
-                                }]  }
-                            ],
+                        results: vec![crate::Result {
+                            substitutions: vec![Substitution {
+                                variable: "foo".to_string(),
+                                term: Term {
+                                    name: "bar".to_string(),
+                                    arguments: vec![],
+                                },
+                            }],
+                        }],
                     }),
                 }),
             };

--- a/packages/logic-bindings/src/testing/mock.rs
+++ b/packages/logic-bindings/src/testing/mock.rs
@@ -1,0 +1,77 @@
+use std::marker::PhantomData;
+use cosmwasm_std::{Coin, OwnedDeps, QuerierResult, SystemError, SystemResult, Uint128};
+use cosmwasm_std::testing::{BankQuerier, MOCK_CONTRACT_ADDR, MockApi, MockQuerier, MockStorage};
+use serde::de::DeserializeOwned;
+use crate::LogicCustomQuery;
+
+/// Creates all external requirements that can be injected for unit tests.
+///
+/// It sets the given balance for the contract itself, nothing else and set the custom default logic
+/// querier handler.
+pub fn mock_dependencies_with_logic_and_balance( contract_balance: &[Coin],
+) -> OwnedDeps<MockStorage, MockApi, MockQuerier<LogicCustomQuery>, LogicCustomQuery> {
+    mock_dependencies_with_logic_and_balances(&[(MOCK_CONTRACT_ADDR, contract_balance)])
+}
+
+/// Initializes the querier along with the mock_dependencies.
+///
+/// Set the logic querier mock handler.
+/// Sets all balances provided (you must explicitly set contract balance if desired).
+pub fn mock_dependencies_with_logic_and_balances(balances: &[(&str, &[Coin])]) -> OwnedDeps<MockStorage, MockApi, MockQuerier<LogicCustomQuery>, LogicCustomQuery> {
+    OwnedDeps {
+        storage: MockStorage::default(),
+        api: MockApi::default(),
+        querier: MockLogicQuerier::new(LogicQuerier::default(), balances),
+        custom_query_type: PhantomData,
+    }
+
+}
+
+trait MockLogicQuerier {
+    fn new(logic: LogicQuerier, balances: &[(&str, &[Coin])]) -> Self;
+}
+
+impl MockLogicQuerier for MockQuerier<LogicCustomQuery> {
+    fn new(logic: LogicQuerier, balances: &[(&str, &[Coin])]) -> Self {
+        MockQuerier::new(balances).with_custom_handler(Box::new(logic.handler))
+    }
+}
+
+struct LogicQuerier {
+    /// A handler to handle Logic queries. This is set to a dummy handler that
+    /// always errors by default. Update it via `update_handler`.
+    ///
+    /// Use box to avoid the need of generic type.
+    handler: Box<dyn for<'a> Fn(&'a LogicCustomQuery) -> QuerierResult>,
+}
+
+impl LogicQuerier {
+    fn new(handler: Box<dyn for<'a> Fn(&'a LogicCustomQuery) -> QuerierResult>) -> Self {
+        Self { handler }
+    }
+
+    fn update_handler<LH: 'static>(&mut self, handler: LH)
+        where
+            LH: Fn(&LogicCustomQuery) -> QuerierResult,
+    {
+        self.handler = Box::from(handler)
+    }
+
+    fn query(&self, request: &LogicCustomQuery) -> QuerierResult {
+        (*self.handler)(request)
+    }
+}
+
+impl Default for LogicQuerier {
+    fn default() -> Self {
+        let handler = Box::from(|request: &LogicCustomQuery| -> QuerierResult {
+            let err = match request {
+                LogicCustomQuery::Ask { program, query} => SystemError::UnsupportedRequest {
+                    kind: "logic".to_string(),
+                },
+            };
+            SystemResult::Err(err)
+        });
+        Self::new(handler)
+    }
+}

--- a/packages/logic-bindings/src/testing/mock.rs
+++ b/packages/logic-bindings/src/testing/mock.rs
@@ -1,7 +1,6 @@
 use std::marker::PhantomData;
-use cosmwasm_std::{Coin, OwnedDeps, QuerierResult, SystemError, SystemResult, to_binary, Uint128};
-use cosmwasm_std::testing::{BankQuerier, MOCK_CONTRACT_ADDR, MockApi, MockQuerier, MockStorage};
-use serde::de::DeserializeOwned;
+use cosmwasm_std::{Coin, OwnedDeps, QuerierResult, SystemResult, to_binary};
+use cosmwasm_std::testing::{MOCK_CONTRACT_ADDR, MockApi, MockQuerier, MockStorage};
 use crate::{Answer, AskResponse, LogicCustomQuery, Substitution, Term};
 
 /// Creates all external requirements that can be injected for unit tests.
@@ -50,15 +49,12 @@ impl LogicQuerier {
         Self { handler }
     }
 
+    #[allow(dead_code)]
     fn update_handler<LH: 'static>(&mut self, handler: LH)
         where
             LH: Fn(&LogicCustomQuery) -> QuerierResult,
     {
         self.handler = Box::from(handler)
-    }
-
-    fn query(&self, request: &LogicCustomQuery) -> QuerierResult {
-        (*self.handler)(request)
     }
 }
 
@@ -66,7 +62,7 @@ impl Default for LogicQuerier {
     fn default() -> Self {
         let handler = Box::from(|request: &LogicCustomQuery| -> QuerierResult {
             let result = match request {
-                LogicCustomQuery::Ask { program, query} => to_binary(&AskResponse {
+                LogicCustomQuery::Ask { .. } => to_binary(&AskResponse {
                     height: 1,
                     gas_used: 1000,
                     answer: Some(Answer {

--- a/packages/logic-bindings/src/testing/mod.rs
+++ b/packages/logic-bindings/src/testing/mod.rs
@@ -1,8 +1,6 @@
-mod query;
-
-pub use query::{Answer, AskResponse, LogicCustomQuery, Result, Substitution, Term};
+#![cfg(not(target_arch = "wasm32"))]
 
 // Exposed for testing only
 // Both unit tests and integration tests are compiled to native code, so everything in here does not need to compile to Wasm.
-#[cfg(not(target_arch = "wasm32"))]
-pub mod testing;
+
+pub mod mock;


### PR DESCRIPTION
#### 📝 Purpose 

Trying the testing process on cosmwasm smart contract, I've added a unit test of the new `cw-logic-sample` (#114) smart contract. 

#### 🕹️ Mock

To do that, a MockLogicQuerier has been introduced allowing mock the logic module. A default implementation has been set to return a successful Answer whatever program or query set initially with a Foo / Bar variable substitution. 

Is intended to just check if the `cw-logic-sample` contract, `Ask` query, requests the logic module.   

#### 🚨 Linter

In addition, I've introduce some unused import so I've enforced the linter rules 😈 😈. I'm nice because I haven't add the `missing_docs` rules 😇.
