### PR TITLE
📏 CI: Add new wasm binary for size limit

### DIFF
--- a/.size-limit.json
+++ b/.size-limit.json
@@ -4,5 +4,11 @@
     "running": false,
     "brotli": false,
     "gzip": false
+  },
+  {
+    "path": "target/wasm32-unknown-unknown/release/cw_logic_sample.wasm",
+    "running": false,
+    "brotli": false,
+    "gzip": false
   }
 ]


### PR DESCRIPTION
Add the new `cw-logic-sample` contract into the `.size-limit` configuration to show the size report on next PR. 

Initially, I wanted to add the [pattern that groups](https://github.com/ai/size-limit#limits-config) all the `*.wasm` into the size-limit config but when doing that, size-limit will merge and increment all wasm size into one result total size. This is not representative to our needs. So we will need to add manually all new smart contract wasm in a new config section for each smart contract. 