### PR TITLE
💿 Storage: Pin / Unpin object

### DIFF
--- a/Makefile.toml
+++ b/Makefile.toml
@@ -66,9 +66,9 @@ description = "Run all unit tests."
 env = { LLVM_PROFILE_FILE = "default.profraw", RUST_BACKTRACE = 1 }
 
 [tasks.test-coverage]
-dependencies = ["install-tarpaulin"]
-command = "cargo"
 args = ["tarpaulin", "-o", "lcov"]
+command = "cargo"
+dependencies = ["install-tarpaulin"]
 
 [tasks.install_wasm]
 script = '''

--- a/Makefile.toml
+++ b/Makefile.toml
@@ -430,6 +430,44 @@ docker run --rm \
       | jq -r '.'
 '''
 
+[tasks.chain-execute-contract]
+dependencies = ["chain-start"]
+description = "Execute a command on a specific contract to the chain. The contract must be already deployed and instantiated."
+script = '''
+if [ -z "$1" ]
+then
+  echo "❌ Please provide the contract address as the first argument."
+  exit 1
+fi
+addr=$1
+
+if [ -z "$2" ]
+then
+  echo "❌ Please provide the contract execute msg as the second argument."
+  exit 1
+fi
+msgs=$2
+
+echo "📦 Execute on contract ${addr} to chain ${CHAIN}"
+docker run --rm \
+  --network host \
+  -v `pwd`:/app:ro \
+  -w /app \
+  ${DOCKER_IMAGE_OKP4D} \
+    tx wasm execute ${addr} "${msgs}" \
+      --from validator \
+      --keyring-backend test \
+      --home ${CHAIN_HOME} \
+      --gas-prices 0.025uknow \
+      --gas auto \
+      --gas-adjustment 1.5 \
+      --chain-id ${CHAIN} \
+      --broadcast-mode block \
+      --yes \
+      --output json \
+      | jq -r '.'
+'''
+
 [tasks.install-llvm-tools-preview]
 install_crate = { rustup_component_name = "llvm-tools-preview" }
 

--- a/README.md
+++ b/README.md
@@ -78,6 +78,7 @@ chain-add-keys - Add a set of predefined keys (recovered from the seed phrases) 
 chain-clean - Clean the chain data (⚠️ definitively)
 chain-deploy-contract - Deploy a specific contract to the chain. The contract must be compiled and the wasm file must be present in the artifacts directory (under target/wasm32-unknown-unknown/...).
 chain-deploy-contracts - Deploy all the available contracts to the chain (under target/wasm32-unknown-unknown/...).
+chain-execute-contract - Execute a command on a specific contract to the chain. The contract must be already deployed and instantiated.
 chain-init-folder - Initialize deploy folder to make sure scripts have the right permission (needed for linux)
 chain-initialize - Initialize the chain with a validator's key and a set of predefined keys. ⚠️ The home directory is cleaned before.
 chain-inspect-contract - Inspect a specific contract deployed to the chain.

--- a/contracts/cw-storage/Cargo.toml
+++ b/contracts/cw-storage/Cargo.toml
@@ -27,6 +27,7 @@ panic = 'abort'
 rpath = false
 
 [dependencies]
+base16ct = "0.1.1"
 cosmwasm-schema.workspace = true
 cosmwasm-std.workspace = true
 cosmwasm-storage.workspace = true
@@ -34,13 +35,12 @@ cw-storage-plus.workspace = true
 cw2.workspace = true
 schemars.workspace = true
 serde.workspace = true
-thiserror.workspace = true
 sha2 = "0.10.6"
-base16ct = "0.1.1"
+thiserror.workspace = true
 
 [dev-dependencies]
-cw-multi-test.workspace = true
 base64 = "0.21.0"
+cw-multi-test.workspace = true
 
 [features]
 # for more explicit tests, cargo test --features=backtraces

--- a/contracts/cw-storage/src/contract.rs
+++ b/contracts/cw-storage/src/contract.rs
@@ -150,7 +150,9 @@ pub mod execute {
             Limits {
                 max_object_pins: Some(max),
                 ..
-            } if max < o.pin_count => Err(BucketError::MaxObjectPinsLimitExceeded.into()),
+            } if max < o.pin_count => {
+                Err(BucketError::MaxObjectPinsLimitExceeded(o.pin_count, max).into())
+            }
             _ => {
                 pins().save(
                     deps.storage,
@@ -777,7 +779,10 @@ mod tests {
                     mock_info("pierre", &[]),
                 ],
                 expected_count: 3,
-                expected_error: Some(ContractError::Bucket(MaxObjectPinsLimitExceeded)),
+                expected_error: Some(ContractError::Bucket(MaxObjectPinsLimitExceeded(
+                    Uint128::new(3),
+                    Uint128::new(2),
+                ))),
                 expected_object_pin_count: vec![
                     (
                         ObjectId::from(

--- a/contracts/cw-storage/src/contract.rs
+++ b/contracts/cw-storage/src/contract.rs
@@ -94,6 +94,7 @@ pub mod execute {
             id: sha256_hash(&data.0),
             owner: info.sender.clone(),
             size,
+            pin_count: if pin { Uint128::one() } else { Uint128::zero() }
         };
         let res = Response::new()
             .add_attribute("action", "store_object")

--- a/contracts/cw-storage/src/contract.rs
+++ b/contracts/cw-storage/src/contract.rs
@@ -340,6 +340,7 @@ mod tests {
             assert_eq!(created.id, obj.2);
             assert_eq!(created.owner, info.clone().sender);
             assert_eq!(created.size.u128(), obj.3);
+            assert_eq!(created.pin_count, if obj.1 { Uint128::one() } else { Uint128::zero() });
 
             assert_eq!(
                 pins().has(&deps.storage, (String::from(obj.2), info.clone().sender)),

--- a/contracts/cw-storage/src/contract.rs
+++ b/contracts/cw-storage/src/contract.rs
@@ -875,4 +875,236 @@ mod tests {
             }
         }
     }
+
+    struct TestUnpinCase {
+        pin: Vec<ObjectId>,
+        pin_senders: Vec<MessageInfo>,
+        unpin: Vec<ObjectId>,
+        unpin_senders: Vec<MessageInfo>,
+        expected_count: usize,
+        expected_error: Option<ContractError>,
+        expected_object_pin_count: Vec<(ObjectId, Uint128)>,
+    }
+
+    #[test]
+    fn unpin_object() {
+        let cases = vec![
+            TestUnpinCase {
+                pin: vec![ObjectId::from(
+                    "315d0d9ab12c5f8884100055f79de50b72db4bd2c9bfd3df049d89640fed1fa6",
+                )],
+                pin_senders: vec![mock_info("bob", &[])],
+                unpin: vec![ObjectId::from(
+                    "315d0d9ab12c5f8884100055f79de50b72db4bd2c9bfd3df049d89640fed1fa6",
+                )],
+                unpin_senders: vec![mock_info("bob", &[])],
+                expected_count: 0,
+                expected_error: None,
+                expected_object_pin_count: vec![(
+                    ObjectId::from(
+                        "315d0d9ab12c5f8884100055f79de50b72db4bd2c9bfd3df049d89640fed1fa6",
+                    ),
+                    Uint128::zero(),
+                )],
+            },
+            TestUnpinCase {
+                pin: vec![ObjectId::from(
+                    "315d0d9ab12c5f8884100055f79de50b72db4bd2c9bfd3df049d89640fed1fa6",
+                )],
+                pin_senders: vec![mock_info("bob", &[])],
+                unpin: vec![ObjectId::from(
+                    "2cf24dba5fb0a30e26e83b2ac5b9e29e1b161e5c1fa7425e73043362938b9824",
+                )],
+                unpin_senders: vec![mock_info("bob", &[])],
+                expected_count: 1,
+                expected_error: None,
+                expected_object_pin_count: vec![
+                    (
+                        ObjectId::from(
+                            "315d0d9ab12c5f8884100055f79de50b72db4bd2c9bfd3df049d89640fed1fa6",
+                        ),
+                        Uint128::one(),
+                    ),
+                    (
+                        ObjectId::from(
+                            "2cf24dba5fb0a30e26e83b2ac5b9e29e1b161e5c1fa7425e73043362938b9824",
+                        ),
+                        Uint128::zero(),
+                    ),
+                ],
+            },
+            TestUnpinCase {
+                pin: vec![
+                    ObjectId::from(
+                        "315d0d9ab12c5f8884100055f79de50b72db4bd2c9bfd3df049d89640fed1fa6",
+                    ),
+                    ObjectId::from(
+                        "2cf24dba5fb0a30e26e83b2ac5b9e29e1b161e5c1fa7425e73043362938b9824",
+                    ),
+                ],
+                pin_senders: vec![mock_info("bob", &[]), mock_info("bob", &[])],
+                unpin: vec![ObjectId::from(
+                    "315d0d9ab12c5f8884100055f79de50b72db4bd2c9bfd3df049d89640fed1fa6",
+                )],
+                unpin_senders: vec![mock_info("bob", &[])],
+                expected_count: 1,
+                expected_error: None,
+                expected_object_pin_count: vec![
+                    (
+                        ObjectId::from(
+                            "315d0d9ab12c5f8884100055f79de50b72db4bd2c9bfd3df049d89640fed1fa6",
+                        ),
+                        Uint128::zero(),
+                    ),
+                    (
+                        ObjectId::from(
+                            "2cf24dba5fb0a30e26e83b2ac5b9e29e1b161e5c1fa7425e73043362938b9824",
+                        ),
+                        Uint128::one(),
+                    ),
+                ],
+            },
+            TestUnpinCase {
+                pin: vec![],
+                pin_senders: vec![],
+                unpin: vec![ObjectId::from(
+                    "315d0d9ab12c5f8884100055f79de50b72db4bd2c9bfd3df049d89640fed1fa6",
+                )],
+                unpin_senders: vec![mock_info("bob", &[])],
+                expected_count: 0,
+                expected_error: None,
+                expected_object_pin_count: vec![(
+                    ObjectId::from(
+                        "315d0d9ab12c5f8884100055f79de50b72db4bd2c9bfd3df049d89640fed1fa6",
+                    ),
+                    Uint128::zero(),
+                )],
+            },
+            TestUnpinCase {
+                pin: vec![
+                    ObjectId::from(
+                        "315d0d9ab12c5f8884100055f79de50b72db4bd2c9bfd3df049d89640fed1fa6",
+                    ),
+                    ObjectId::from(
+                        "2cf24dba5fb0a30e26e83b2ac5b9e29e1b161e5c1fa7425e73043362938b9824",
+                    ),
+                    ObjectId::from(
+                        "2cf24dba5fb0a30e26e83b2ac5b9e29e1b161e5c1fa7425e73043362938b9824",
+                    ),
+                    ObjectId::from(
+                        "2cf24dba5fb0a30e26e83b2ac5b9e29e1b161e5c1fa7425e73043362938b9824",
+                    ),
+                ],
+                pin_senders: vec![
+                    mock_info("bob", &[]),
+                    mock_info("alice", &[]),
+                    mock_info("martin", &[]),
+                    mock_info("pierre", &[]),
+                ],
+                unpin: vec![ObjectId::from(
+                    "2cf24dba5fb0a30e26e83b2ac5b9e29e1b161e5c1fa7425e73043362938b9824",
+                )],
+                unpin_senders: vec![mock_info("martin", &[])],
+                expected_count: 3,
+                expected_error: None,
+                expected_object_pin_count: vec![
+                    (
+                        ObjectId::from(
+                            "315d0d9ab12c5f8884100055f79de50b72db4bd2c9bfd3df049d89640fed1fa6",
+                        ),
+                        Uint128::one(),
+                    ),
+                    (
+                        ObjectId::from(
+                            "2cf24dba5fb0a30e26e83b2ac5b9e29e1b161e5c1fa7425e73043362938b9824",
+                        ),
+                        Uint128::new(2),
+                    ),
+                ],
+            },
+        ];
+
+        for case in cases {
+            let mut deps = mock_dependencies();
+            let info = mock_info("creator", &[]);
+
+            instantiate(
+                deps.as_mut(),
+                mock_env(),
+                info.clone(),
+                InstantiateMsg {
+                    bucket: "test".to_string(),
+                    limits: BucketLimits::new(),
+                },
+            )
+            .unwrap();
+
+            let data = general_purpose::STANDARD.encode("okp4");
+            let msg = ExecuteMsg::StoreObject {
+                data: Binary::from_base64(data.as_str()).unwrap(),
+                pin: false,
+            };
+            let _ = execute(deps.as_mut(), mock_env(), info.clone(), msg).unwrap();
+
+            let data = general_purpose::STANDARD.encode("data");
+            let msg = ExecuteMsg::StoreObject {
+                data: Binary::from_base64(data.as_str()).unwrap(),
+                pin: false,
+            };
+            let _ = execute(deps.as_mut(), mock_env(), info.clone(), msg).unwrap();
+
+            let data = general_purpose::STANDARD.encode("hello");
+            let msg = ExecuteMsg::StoreObject {
+                data: Binary::from_base64(data.as_str()).unwrap(),
+                pin: false,
+            };
+            let _ = execute(deps.as_mut(), mock_env(), info.clone(), msg).unwrap();
+
+            let mut last_result: Option<Result<Response, ContractError>> = None;
+            case.pin
+                .iter()
+                .zip(case.pin_senders)
+                .for_each(|(object_id, info)| {
+                    last_result = Some(execute(
+                        deps.as_mut(),
+                        mock_env(),
+                        info,
+                        ExecuteMsg::PinObject {
+                            id: object_id.clone(),
+                        },
+                    ));
+                });
+            case.unpin
+                .iter()
+                .zip(case.unpin_senders)
+                .for_each(|(object_id, info)| {
+                    last_result = Some(execute(
+                        deps.as_mut(),
+                        mock_env(),
+                        info,
+                        ExecuteMsg::UnpinObject {
+                            id: object_id.clone(),
+                        },
+                    ));
+                });
+
+            match case.expected_error {
+                Some(err) => assert_eq!(last_result.unwrap().unwrap_err(), err),
+                _ => {
+                    assert_eq!(
+                        pins()
+                            .keys_raw(&deps.storage, None, None, Order::Ascending)
+                            .count(),
+                        case.expected_count
+                    );
+                    for (object_id, count) in case.expected_object_pin_count {
+                        assert_eq!(
+                            objects().load(&deps.storage, object_id).unwrap().pin_count,
+                            count
+                        );
+                    }
+                }
+            }
+        }
+    }
 }

--- a/contracts/cw-storage/src/contract.rs
+++ b/contracts/cw-storage/src/contract.rs
@@ -253,6 +253,7 @@ mod tests {
     use cosmwasm_std::testing::{mock_dependencies, mock_env, mock_info};
     use cosmwasm_std::StdError::NotFound;
     use cosmwasm_std::{from_binary, Attribute, Uint128};
+    use std::any::type_name;
 
     #[test]
     fn proper_initialization() {
@@ -802,6 +803,21 @@ mod tests {
                         Uint128::new(2),
                     ),
                 ],
+            },
+            TestPinCase {
+                // Object not exists
+                objects: vec![ObjectId::from("NOTFOUND")],
+                senders: vec![mock_info("bob", &[])],
+                expected_count: 0,
+                expected_error: Some(ContractError::Std(StdError::not_found(
+                    type_name::<Object>(),
+                ))),
+                expected_object_pin_count: vec![(
+                    ObjectId::from(
+                        "315d0d9ab12c5f8884100055f79de50b72db4bd2c9bfd3df049d89640fed1fa6",
+                    ),
+                    Uint128::zero(),
+                )],
             },
         ];
 

--- a/contracts/cw-storage/src/msg.rs
+++ b/contracts/cw-storage/src/msg.rs
@@ -164,7 +164,7 @@ impl BucketLimits {
         self
     }
 
-    pub fn set_object_pins(mut self, max_object_pins: Uint128) -> Self {
+    pub fn set_max_object_pins(mut self, max_object_pins: Uint128) -> Self {
         self.max_object_pins = Some(max_object_pins);
         self
     }

--- a/contracts/cw-storage/src/state.rs
+++ b/contracts/cw-storage/src/state.rs
@@ -94,6 +94,8 @@ pub struct Object {
     pub owner: Addr,
     /// The size of the object.
     pub size: Uint128,
+    /// The number of pin on this object.
+    pub pin_count: Uint128,
 }
 
 pub struct ObjectIndexes<'a> {


### PR DESCRIPTION
### 📝 Description

Implement the `PinObject` and `UnpinObject` execute message. 

### ❓ Question 

What do we do if when we execute PinObject on object that has been already pinned ? The same question for UnpinObject message ? 

Now, if we try to pin an already pinned object, the contract return successful response simulating that the object has just been pinned. Otherwise if we try to unpin an object that is already not pinned to the sender, the contract return also a successful response, by doing this on the unpin object and to limit access to the state, there is no verification on the objects state to check if object exist when trying to unpin object. So if we try to unpin object that does not exist, the contract return successfully because the (ObjectId, senderAddr) tuple doesn't exist in the pins state.

### 🔗 Link

~~Wait #123 before merge~~