### PR TITLE
CI: 🧪 Add codecov upload coverage 

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -44,7 +44,7 @@ jobs:
       - name: Test rust code
         run: cargo make test-coverage
 
-      - name: Upload coverage 
+      - name: Upload coverage
         uses: codecov/codecov-action@v3
         with:
           files: ./lcov.info

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -43,3 +43,9 @@ jobs:
 
       - name: Test rust code
         run: cargo make test-coverage
+
+      - name: Upload coverage 
+        uses: codecov/codecov-action@v3
+        with:
+          files: ./lcov.info
+          fail_ci_if_error: false

--- a/.gitignore
+++ b/.gitignore
@@ -4,4 +4,5 @@ target/
 .DS_Store
 *.profraw
 *.lcov
+lcov.info
 contracts/*/schema/

--- a/Makefile.toml
+++ b/Makefile.toml
@@ -438,7 +438,7 @@ install_crate = { rustup_component_name = "rustfmt" }
 install_crate = { crate_name = "taplo-cli", binary = "taplo", test_arg = "--help" }
 
 [tasks.install-tarpaulin]
-install_crate = { crate_name = "tarpaulin" }
+install_crate = { crate_name = "cargo-tarpaulin" }
 
 [tasks.install-cosmwasm-check]
 install_crate = { crate_name = "cosmwasm-check" }

--- a/Makefile.toml
+++ b/Makefile.toml
@@ -66,10 +66,9 @@ description = "Run all unit tests."
 env = { LLVM_PROFILE_FILE = "default.profraw", RUST_BACKTRACE = 1 }
 
 [tasks.test-coverage]
-dependencies = ["install-grcov", "test"]
-script = '''
-grcov . --binary-path ./target/debug/ -s . -t lcov --branch --ignore-not-existing --ignore "*cargo*" -o coverage.lcov
-'''
+dependencies = ["install-tarpaulin"]
+command = "cargo"
+args = ["tarpaulin", "-o", "lcov"]
 
 [tasks.install_wasm]
 script = '''
@@ -438,8 +437,8 @@ install_crate = { rustup_component_name = "rustfmt" }
 [tasks.install-taplo-cli]
 install_crate = { crate_name = "taplo-cli", binary = "taplo", test_arg = "--help" }
 
-[tasks.install-grcov]
-install_crate = { crate_name = "grcov" }
+[tasks.install-tarpaulin]
+install_crate = { crate_name = "tarpaulin" }
 
 [tasks.install-cosmwasm-check]
 install_crate = { crate_name = "cosmwasm-check" }


### PR DESCRIPTION
Use tarpaulin to produce a `lcov`, then add ci step to upload it to CodeCove. 

This is in replacement of Grcov that is not fully working with this rust project, the coverage was not good. 

This one https://github.com/okp4/contracts/pull/126#issuecomment-1452063342 use grcov but the coverage is wrong.

Now coverage is good : https://app.codecov.io/github/okp4/contracts/commit/9d1931c9f5ddc4337d4a37f15d15606beebc9ac8