### PR TITLE
📖 Enclose generics type in markdown documentation with backticks

### DIFF
--- a/Makefile.toml
+++ b/Makefile.toml
@@ -104,21 +104,26 @@ then
     exit 1
 fi
 
+echo "📚 Generating documentation..."
+
 mkdir -p $SCHEMA_FOLDER
 find contracts/*/schema -type f -maxdepth 1 -name '*.json' \
     -exec sh -c 'cp "$@" "$0"' $SCHEMA_FOLDER/ {} +
 
 for SCHEMA in $(ls $SCHEMA_FOLDER); do
     awk "{sub(\"#/definitions\",\"./${SCHEMA}/#/definitions\")} {print}"  ${SCHEMA_FOLDER}/${SCHEMA} > ${SCHEMA_FOLDER}/tmp
+
     mv ${SCHEMA_FOLDER}/tmp ${SCHEMA_FOLDER}/${SCHEMA}
 done
 
-echo "📚 Generating documentation..."
 rm -rf $DOCS_FOLDER
+
 jsonschema2md -d schema -o $DOCS_FOLDER --schema-extension json --schema-out $DOCS_FOLDER/schema
-echo "📖 Documentation has been successfully generated and available at $(pwd)/$DOCS_FOLDER/README.md"
+sed -i ${SED_FLAG} -E 's/([a-zA-Z]+)<([a-zA-Z0-9]+)>/<code>\1\&lt;\2\&gt;\<\/code>/g' $DOCS_FOLDER/*.md
 
 rm -rf $SCHEMA_FOLDER
+
+echo "📖 Documentation has been successfully generated and available at $(pwd)/$DOCS_FOLDER/README.md"
 '''
 
 [tasks.chain-clean]

--- a/docs/cw-storage-executemsg-definitions-binary.md
+++ b/docs/cw-storage-executemsg-definitions-binary.md
@@ -4,9 +4,9 @@
 undefined#/execute/definitions/Binary
 ```
 
-Binary is a wrapper around Vec<u8> to add base64 de/serialization with serde. It also adds some helper methods to help encode inline.
+Binary is a wrapper around <code>Vec&lt;u8&gt;</code> to add base64 de/serialization with serde. It also adds some helper methods to help encode inline.
 
-This is only needed as serde-json-{core,wasm} has a horrible encoding for Vec<u8>. See also <https://github.com/CosmWasm/cosmwasm/blob/main/docs/MESSAGE_TYPES.md>.
+This is only needed as serde-json-{core,wasm} has a horrible encoding for <code>Vec&lt;u8&gt;</code>. See also <https://github.com/CosmWasm/cosmwasm/blob/main/docs/MESSAGE_TYPES.md>.
 
 | Abstract            | Extensible | Status         | Identifiable            | Custom Properties | Additional Properties | Access Restrictions | Defined In                                                         |
 | :------------------ | :--------- | :------------- | :---------------------- | :---------------- | :-------------------- | :------------------ | :----------------------------------------------------------------- |

--- a/docs/cw-storage-responses-binary.md
+++ b/docs/cw-storage-responses-binary.md
@@ -4,9 +4,9 @@
 undefined#/responses/object_data
 ```
 
-Binary is a wrapper around Vec<u8> to add base64 de/serialization with serde. It also adds some helper methods to help encode inline.
+Binary is a wrapper around <code>Vec&lt;u8&gt;</code> to add base64 de/serialization with serde. It also adds some helper methods to help encode inline.
 
-This is only needed as serde-json-{core,wasm} has a horrible encoding for Vec<u8>. See also <https://github.com/CosmWasm/cosmwasm/blob/main/docs/MESSAGE_TYPES.md>.
+This is only needed as serde-json-{core,wasm} has a horrible encoding for <code>Vec&lt;u8&gt;</code>. See also <https://github.com/CosmWasm/cosmwasm/blob/main/docs/MESSAGE_TYPES.md>.
 
 | Abstract            | Extensible | Status         | Identifiable            | Custom Properties | Additional Properties | Access Restrictions | Defined In                                                         |
 | :------------------ | :--------- | :------------- | :---------------------- | :---------------- | :-------------------- | :------------------ | :----------------------------------------------------------------- |


### PR DESCRIPTION
Self explanatory.

This will resolve , I hope, the issues with the CI for the PRs in the [okp4/docs](https://github.com/okp4/docs) project.