### PR TITLE
Feat/law break stone

### DIFF
--- a/contracts/cw-law-stone/src/contract.rs
+++ b/contracts/cw-law-stone/src/contract.rs
@@ -49,12 +49,26 @@ pub fn instantiate(
 
 #[cfg_attr(not(feature = "library"), entry_point)]
 pub fn execute(
-    _deps: DepsMut<'_>,
-    _env: Env,
-    _info: MessageInfo,
-    _msg: ExecuteMsg,
+    deps: DepsMut<'_>,
+    env: Env,
+    info: MessageInfo,
+    msg: ExecuteMsg,
 ) -> Result<Response, ContractError> {
-    Err(NotImplemented {})
+    match msg {
+        ExecuteMsg::BreakStone => execute::break_stone(deps, env, info),
+    }
+}
+
+pub mod execute {
+    use super::*;
+
+    pub fn break_stone(
+        _deps: DepsMut<'_>,
+        _env: Env,
+        _info: MessageInfo,
+    ) -> Result<Response, ContractError> {
+        Err(NotImplemented {})
+    }
 }
 
 #[cfg_attr(not(feature = "library"), entry_point)]

--- a/contracts/cw-law-stone/src/error.rs
+++ b/contracts/cw-law-stone/src/error.rs
@@ -9,9 +9,6 @@ pub enum ContractError {
     #[error("{0}")]
     Std(#[from] StdError),
 
-    #[error("Not implemented")]
-    NotImplemented {},
-
     #[error("{0}")]
     Parse(#[from] ParseReplyError),
 
@@ -30,7 +27,7 @@ impl ContractError {
         ContractError::LogicLoadUri { error, uri }
     }
 }
-#[derive(Error, Debug)]
+#[derive(Error, Debug, PartialEq)]
 pub enum UriError {
     #[error("{0}")]
     Parse(#[from] ParseError),

--- a/contracts/cw-law-stone/src/error.rs
+++ b/contracts/cw-law-stone/src/error.rs
@@ -4,7 +4,7 @@ use serde_json_wasm::de::Error;
 use thiserror::Error;
 use url::ParseError;
 
-#[derive(Error, Debug)]
+#[derive(Error, Debug, PartialEq)]
 pub enum ContractError {
     #[error("{0}")]
     Std(#[from] StdError),

--- a/contracts/cw-law-stone/src/error.rs
+++ b/contracts/cw-law-stone/src/error.rs
@@ -20,6 +20,9 @@ pub enum ContractError {
 
     #[error("Failed parse dependency uri {uri:?}: {error:?}")]
     LogicLoadUri { error: UriError, uri: String },
+
+    #[error("Only the contract admin can perform this operation.")]
+    Unauthorized {},
 }
 
 impl ContractError {

--- a/contracts/cw-law-stone/src/error.rs
+++ b/contracts/cw-law-stone/src/error.rs
@@ -27,7 +27,7 @@ impl ContractError {
         ContractError::LogicLoadUri { error, uri }
     }
 }
-#[derive(Error, Debug, PartialEq)]
+#[derive(Error, Debug, PartialEq, Eq)]
 pub enum UriError {
     #[error("{0}")]
     Parse(#[from] ParseError),

--- a/contracts/cw-law-stone/src/msg.rs
+++ b/contracts/cw-law-stone/src/msg.rs
@@ -1,4 +1,3 @@
-use crate::state::Object;
 use cosmwasm_schema::{cw_serde, QueryResponses};
 use cosmwasm_std::Binary;
 #[allow(unused_imports)]
@@ -50,13 +49,4 @@ pub struct ProgramResponse {
 
     /// The `cw-storage` contract address on which the law program is stored.
     pub storage_address: String,
-}
-
-impl From<Object> for ProgramResponse {
-    fn from(o: Object) -> Self {
-        ProgramResponse {
-            object_id: o.object_id,
-            storage_address: o.storage_address,
-        }
-    }
 }

--- a/contracts/cw-law-stone/src/state.rs
+++ b/contracts/cw-law-stone/src/state.rs
@@ -13,6 +13,12 @@ use url::Url;
 /// State to store context during contract instantiation
 pub const INSTANTIATE_CONTEXT: Item<'_, String> = Item::new("instantiate");
 
+#[derive(Serialize, Deserialize, Clone, Debug, PartialEq, Eq, JsonSchema)]
+pub struct LawStone {
+    pub broken: bool,
+    pub law: Object,
+}
+
 /// Represent a link to an Object stored in the `cw-storage` contract.
 #[derive(Serialize, Deserialize, Clone, Debug, PartialEq, Eq, JsonSchema)]
 pub struct Object {
@@ -96,7 +102,7 @@ impl TryInto<Url> for Object {
     }
 }
 
-pub const PROGRAM: Item<'_, Object> = Item::new("program");
+pub const PROGRAM: Item<'_, LawStone> = Item::new("program");
 
 pub const DEPENDENCIES: Map<'_, &str, Object> = Map::new("dependencies");
 

--- a/contracts/cw-law-stone/src/state.rs
+++ b/contracts/cw-law-stone/src/state.rs
@@ -4,6 +4,7 @@ use serde::{Deserialize, Serialize};
 use std::collections::HashMap;
 
 use crate::error::UriError;
+use crate::msg::ProgramResponse;
 use crate::ContractError;
 use cw_storage::msg::QueryMsg as StorageQuery;
 use cw_storage::msg::QueryMsg;
@@ -17,6 +18,15 @@ pub const INSTANTIATE_CONTEXT: Item<'_, String> = Item::new("instantiate");
 pub struct LawStone {
     pub broken: bool,
     pub law: Object,
+}
+
+impl From<LawStone> for ProgramResponse {
+    fn from(value: LawStone) -> ProgramResponse {
+        ProgramResponse {
+            object_id: value.law.object_id,
+            storage_address: value.law.storage_address,
+        }
+    }
 }
 
 /// Represent a link to an Object stored in the `cw-storage` contract.


### PR DESCRIPTION
Implements the `BreakStone` execute message.

## Details

An additional `broken` flag has been added to the state which is passed to `false` when breaking the stone.

To release all the used objects, all the dependencies are unpinned, and the main program object is forgot if possible or unpinned.

## Example

```sh
okp4d tx wasm execute \
    --from $YOUR_ADDRESS \
    okp41dea20d4spd7dtwtg84j3cpaj70hju4kjnlr84nn8ftngcmkc5vhqw5jy6e \
    '"break_stone"'
```