### PR TITLE
ci(release): make schema before generating docs

### DIFF
--- a/.releaserc.yml
+++ b/.releaserc.yml
@@ -18,6 +18,7 @@ plugins:
           to: version = "${nextRelease.version}"
   - - "@semantic-release/exec"
     - prepareCmd: |
+        cargo make schema
         cargo make generate_docs
         cargo make release_assets
   - - "@semantic-release/github"


### PR DESCRIPTION
Fix the release process by making the schema before generating the documentation.