### PR TITLE
ci(lint): make lint workflow callable from release

### DIFF
--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -1,13 +1,13 @@
 name: Lint
 
 on:
+  workflow_call:
+
   push:
     branches: [ main ]
 
   pull_request:
     branches: [ main ]
-
-  workflow_dispatch:
 
 jobs:
   lint-commits:


### PR DESCRIPTION
Make the `Lint` workflow callable from the `Release` workflow.