### PR TITLE
build(deps): omit version on path referenced owned packages

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -2,6 +2,7 @@
 members = ["contracts/*", "packages/*"]
 
 [workspace.dependencies]
+logic-bindings = { path = "packages/logic-bindings" }
 cosmwasm-schema = "1.2.3"
 cosmwasm-std = "1.2.3"
 cosmwasm-storage = "1.2.3"

--- a/contracts/cw-law-stone/Cargo.toml
+++ b/contracts/cw-law-stone/Cargo.toml
@@ -27,6 +27,7 @@ panic = 'abort'
 rpath = false
 
 [dependencies]
+logic-bindings.workspace = true
 cosmwasm-schema.workspace = true
 cosmwasm-std.workspace = true
 cosmwasm-storage.workspace = true
@@ -35,7 +36,6 @@ cw-storage-plus.workspace = true
 cw-utils.worksapce = true
 cw2.workspace = true
 form_urlencoded = "1.1.0"
-logic-bindings = { version = "0.2", path = "../../packages/logic-bindings" }
 schemars.workspace = true
 serde-json-wasm.workspace = true
 serde.workspace = true


### PR DESCRIPTION
When releasing it is difficult to update packages versions like `logic-bindings` when imported in contracts. I propose through this PR to omit the version when importing a package referenced by path for which the codebase is maintained in this repository, as we can't referenced a different version anyway.