### PR TITLE
ci(docs): fix publish docs released

### DIFF
--- a/.github/workflows/notify-release.yml
+++ b/.github/workflows/notify-release.yml
@@ -37,6 +37,7 @@ jobs:
                 "version": "${{ github.event.release.tag_name }}",
                 "repository": "${{github.repository}}",
                 "section": "contracts",
-                "docs_directory": "docs/*"
+                "docs_directory": "docs/*",
+                "draft": "false"
               }
             }


### PR DESCRIPTION
Draft input should be given as String and not as boolean due to an issue on GitHub action input. The default value on docs repository is not working. 