### PR TITLE
[💿 Objectarium] 🐛 Fix store forgotten object

### DIFF
--- a/contracts/okp4-objectarium/src/contract.rs
+++ b/contracts/okp4-objectarium/src/contract.rs
@@ -265,6 +265,7 @@ pub mod execute {
         })?;
 
         objects().remove(deps.storage, object_id.clone())?;
+        DATA.remove(deps.storage, object_id.clone());
         Ok(Response::new()
             .add_attribute("action", "forget_object")
             .add_attribute("id", object_id))
@@ -2165,7 +2166,7 @@ mod tests {
         .unwrap();
 
         let data = general_purpose::STANDARD.encode("data");
-        let b = execute(
+        let _ = execute(
             deps.as_mut(),
             mock_env(),
             info.clone(),
@@ -2190,7 +2191,7 @@ mod tests {
         let result = execute(
             deps.as_mut(),
             mock_env(),
-            info.clone(),
+            info,
             ExecuteMsg::StoreObject {
                 data: Binary::from_base64(data.as_str()).unwrap(),
                 pin: false,

--- a/contracts/okp4-objectarium/src/contract.rs
+++ b/contracts/okp4-objectarium/src/contract.rs
@@ -59,7 +59,7 @@ pub mod execute {
     use crate::compress::CompressionAlgorithm;
     use crate::msg;
     use crate::state::BucketLimits;
-    use crate::ContractError::ObjectAlreadyPinned;
+    use crate::ContractError::ObjectPinned;
     use cosmwasm_std::{Order, StdError, Uint128};
     use std::any::type_name;
 
@@ -255,7 +255,7 @@ pub mod execute {
             .next()
             .is_some()
         {
-            return Err(ObjectAlreadyPinned {});
+            return Err(ObjectPinned {});
         }
         let object = query::object(deps.as_ref(), object_id.clone())?;
         BUCKET.update(deps.storage, |mut b| -> Result<_, ContractError> {
@@ -2015,7 +2015,7 @@ mod tests {
                 forget_senders: vec![mock_info("alice", &[])], // the sender is different from the pinner, so error
                 expected_count: 3,
                 expected_total_size: Uint128::new(13),
-                expected_error: Some(ContractError::ObjectAlreadyPinned {}),
+                expected_error: Some(ContractError::ObjectPinned {}),
             },
             TC {
                 pins: vec![ObjectId::from(
@@ -2046,7 +2046,7 @@ mod tests {
                 forget_senders: vec![mock_info("bob", &[])], // the sender is the same as the pinner, but another pinner is on it so error
                 expected_count: 3,
                 expected_total_size: Uint128::new(13),
-                expected_error: Some(ContractError::ObjectAlreadyPinned {}),
+                expected_error: Some(ContractError::ObjectPinned {}),
             },
         ];
 

--- a/contracts/okp4-objectarium/src/error.rs
+++ b/contracts/okp4-objectarium/src/error.rs
@@ -11,8 +11,8 @@ pub enum ContractError {
     #[error("{0}")]
     Bucket(#[from] BucketError),
 
-    #[error("Object is already pinned")]
-    ObjectAlreadyPinned {},
+    #[error("Object is pinned and cannot be forgotten")]
+    ObjectPinned {},
 
     #[error("Compression error: {0}")]
     CompressionError(String),
@@ -93,10 +93,14 @@ fn test_bucket_error_messages() {
             )),
             "Compression algorithm is not accepted: Snappy (accepted: \"[Passthrough]\")",
         ),
-        (ContractError::ObjectAlreadyPinned {}, "Object is already pinned"),
+        (ContractError::ObjectPinned {}, "Object is pinned and cannot be forgotten"),
         (
             ContractError::CompressionError("Insufficient ch'i to compress file".to_string()),
             "Compression error: Insufficient ch'i to compress file",
+        ),
+        (
+            CompressionError::Error("Cannot compress empty data".to_string()).into(),
+            "Compression error: Cannot compress empty data",
         ),
     ];
 


### PR DESCRIPTION
This PR fix the issue thrown on #220. 

Otherwise, following @amimart [comment's](https://github.com/okp4/contracts/issues/220#issuecomment-1544119185), I've renamed error from `ObjectAlreadyPinned` by `ObjectPinned` with it's corresponding message. The corresponding message seem to be specific to a forgot action but t's only used for this. Feel free to tell me if you see another message more clearer or generic. 