### PR TITLE
🐛 Fix: include Cargo.lock on release

### DIFF
--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -236,7 +236,7 @@ jobs:
         if: steps.changed-toml-files.outputs.any_changed == 'true'
         run: |
           cargo make format-toml
-          if [[ $(git status -s) ]]; then
+          if [[ $(git status -s | grep .toml) ]]; then
             >&2 echo "❌ There is a diff between formatted files and source code"
             >&2 git status
             exit 1

--- a/.releaserc.yml
+++ b/.releaserc.yml
@@ -34,4 +34,5 @@ plugins:
         - contracts/*/Cargo.toml
         - packages/*/Cargo.toml
         - docs/**
+        - Cargo.lock
       message: "chore(release): perform release ${nextRelease.version}"

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -701,7 +701,7 @@ checksum = "2dffe52ecf27772e601905b7522cb4ef790d2cc203488bbd0e2fe85fcb74566d"
 
 [[package]]
 name = "okp4-cognitarium"
-version = "2.0.0"
+version = "2.1.0"
 dependencies = [
  "base64 0.21.2",
  "blake3",
@@ -722,7 +722,7 @@ dependencies = [
 
 [[package]]
 name = "okp4-law-stone"
-version = "2.0.0"
+version = "2.1.0"
 dependencies = [
  "cosmwasm-schema",
  "cosmwasm-std",
@@ -743,7 +743,7 @@ dependencies = [
 
 [[package]]
 name = "okp4-logic-bindings"
-version = "2.0.0"
+version = "2.1.0"
 dependencies = [
  "cosmwasm-std",
  "form_urlencoded",
@@ -756,7 +756,7 @@ dependencies = [
 
 [[package]]
 name = "okp4-objectarium"
-version = "2.0.0"
+version = "2.1.0"
 dependencies = [
  "base16ct 0.2.0",
  "base64 0.21.2",
@@ -780,7 +780,7 @@ dependencies = [
 
 [[package]]
 name = "okp4-objectarium-client"
-version = "2.0.0"
+version = "2.1.0"
 dependencies = [
  "cosmwasm-std",
  "okp4-logic-bindings",

--- a/Makefile.toml
+++ b/Makefile.toml
@@ -68,7 +68,7 @@ rustup target add wasm32-unknown-unknown
 '''
 
 [tasks.wasm]
-args = ["build", "--release", "--lib", "--target", "wasm32-unknown-unknown"]
+args = ["build", "--release", "--lib", "--target", "wasm32-unknown-unknown", "--locked"]
 command = "cargo"
 dependencies = ["install-wasm"]
 env = { RUSTFLAGS = "-C link-arg=-s" }

--- a/Makefile.toml
+++ b/Makefile.toml
@@ -68,7 +68,14 @@ rustup target add wasm32-unknown-unknown
 '''
 
 [tasks.wasm]
-args = ["build", "--release", "--lib", "--target", "wasm32-unknown-unknown", "--locked"]
+args = [
+  "build",
+  "--release",
+  "--lib",
+  "--target",
+  "wasm32-unknown-unknown",
+  "--locked",
+]
 command = "cargo"
 dependencies = ["install-wasm"]
 env = { RUSTFLAGS = "-C link-arg=-s" }


### PR DESCRIPTION
Multiple issue has been fixed in this PR. 

After a release, lint workflow `lint-toml-format` [fail](https://github.com/okp4/contracts/actions/runs/5387992338/jobs/9780057788). When checking `.toml` format, git detect change on `Cargo.lock`, after a release it's the self dependencies that has been updated inside. Lint failed because there is a change (but not on `.toml` files). 
- Include `Cargo.lock` file in asset to be included in release commit. 
- Add the `--locked` args when building wasm target to prevent cargo dependencies update on ci.
- Select only `.toml` files when checking changed files on `lint-toml-format` GitHub action.