### PR TITLE
refactor(objectarium): derive default hash algorithm

### DIFF
--- a/contracts/okp4-objectarium/src/state.rs
+++ b/contracts/okp4-objectarium/src/state.rs
@@ -67,24 +67,19 @@ impl Bucket {
 
 /// HashAlgorithm is an enumeration that defines the different hash algorithms
 /// supported for hashing the content of objects.
-#[derive(Serialize, Copy, Deserialize, Clone, Debug, PartialEq, Eq, JsonSchema)]
+#[derive(Serialize, Copy, Deserialize, Clone, Debug, PartialEq, Eq, JsonSchema, Default)]
 pub enum HashAlgorithm {
     /// Represents the MD5 algorithm.
     MD5,
     /// Represents the SHA-224 algorithm.
     Sha224,
     /// Represents the SHA-256 algorithm.
+    #[default]
     Sha256,
     /// Represents the SHA-384 algorithm.
     Sha384,
     /// Represents the SHA-512 algorithm.
     Sha512,
-}
-
-impl Default for HashAlgorithm {
-    fn default() -> Self {
-        HashAlgorithm::Sha256
-    }
 }
 
 impl From<msg::HashAlgorithm> for HashAlgorithm {


### PR DESCRIPTION
Derives default hash algorithm value in objectarium state rather than to implement the default function. This makes the implementation less verbose and also appeases our linter 🙂 See action error message: https://github.com/okp4/contracts/actions/runs/5736567463/job/15546422078?pr=296 