### PR TITLE
 🤯 CONSTRUCT query specification 

### DIFF
--- a/contracts/okp4-cognitarium/src/contract.rs
+++ b/contracts/okp4-cognitarium/src/contract.rs
@@ -80,7 +80,12 @@ pub fn query(deps: Deps<'_>, _env: Env, msg: QueryMsg) -> StdResult<Binary> {
         QueryMsg::Describe { query, format } => to_binary(&query::describe(
             deps,
             query,
-            format.unwrap_or(DataFormat::Turtle),
+            format.unwrap_or(DataFormat::default()),
+        )?),
+        QueryMsg::Construct { query, format } => to_binary(&query::construct(
+            deps,
+            query,
+            format.unwrap_or(DataFormat::default()),
         )?),
     }
 }
@@ -90,9 +95,9 @@ pub mod query {
 
     use super::*;
     use crate::msg::{
-        DescribeQuery, DescribeResponse, Node, Prefix, SelectItem, SelectQuery, SelectResponse,
-        SimpleWhereCondition, StoreResponse, TriplePattern, Value, VarOrNamedNode, VarOrNode,
-        VarOrNodeOrLiteral, WhereCondition,
+        ConstructQuery, DescribeQuery, DescribeResponse, Node, Prefix, SelectItem, SelectQuery,
+        SelectResponse, SimpleWhereCondition, StoreResponse, TriplePattern, Value, VarOrNamedNode,
+        VarOrNode, VarOrNodeOrLiteral, WhereCondition,
     };
     use crate::querier::{PlanBuilder, QueryEngine};
     use crate::rdf::{self, Atom, TripleWriter};
@@ -223,6 +228,14 @@ pub mod query {
             format,
             data: Binary::from(out),
         })
+    }
+
+    pub fn construct(
+        _deps: Deps<'_>,
+        _query: ConstructQuery,
+        _format: DataFormat,
+    ) -> StdResult<SelectResponse> {
+        todo!()
     }
 }
 

--- a/contracts/okp4-cognitarium/src/msg.rs
+++ b/contracts/okp4-cognitarium/src/msg.rs
@@ -107,12 +107,26 @@ pub enum QueryMsg {
         /// If not provided, the default format is [Turtle](https://www.w3.org/TR/turtle/) format.
         format: Option<DataFormat>,
     },
+
+    /// # Construct
+    ///
+    /// Returns the resources matching the criteria defined by the provided query as a set of RDF
+    /// triples serialized in the provided format.
+    #[returns(ConstructResponse)]
+    Construct {
+        /// The query to execute.
+        query: ConstructQuery,
+        /// The format in which the triples are serialized.
+        /// If not provided, the default format is [Turtle](https://www.w3.org/TR/turtle/) format.
+        format: Option<DataFormat>,
+    },
 }
 
 /// # DataFormat
 /// Represents the format in which the data are serialized, for example when returned by a query or
 /// when inserted in the store.
 #[cw_serde]
+#[derive(Default)]
 pub enum DataFormat {
     /// # RDF XML
     /// Output in [RDF/XML](https://www.w3.org/TR/rdf-syntax-grammar/) format.
@@ -121,6 +135,7 @@ pub enum DataFormat {
     /// # Turtle
     /// Output in [Turtle](https://www.w3.org/TR/turtle/) format.
     #[serde(rename = "turtle")]
+    #[default]
     Turtle,
     /// # N-Triples
     /// Output in [N-Triples](https://www.w3.org/TR/n-triples/) format.
@@ -308,6 +323,16 @@ pub struct DescribeResponse {
     pub data: Binary,
 }
 
+/// # ConstructResponse
+/// Represents the response of a [QueryMsg::Construct] query.
+#[cw_serde]
+pub struct ConstructResponse {
+    /// The format of the data.
+    pub format: DataFormat,
+    /// The data serialized in the specified format.
+    pub data: Binary,
+}
+
 /// # Head
 /// Represents the head of a [SelectResponse].
 #[cw_serde]
@@ -386,6 +411,21 @@ pub struct DescribeQuery {
     pub resource: VarOrNamedNode,
     /// The WHERE clause.
     /// This clause is used to specify the resource identifier to describe using variable bindings.
+    pub r#where: WhereClause,
+}
+
+/// # ConstructQuery
+/// Represents a CONSTRUCT query over the triple store, allowing to retrieve a set of triples
+/// serialized in a specific format.
+#[cw_serde]
+pub struct ConstructQuery {
+    /// The prefixes used in the query.
+    pub prefixes: Vec<Prefix>,
+    /// The triples to construct.
+    /// If nothing is provided, the patterns from the `where` clause are used for construction.
+    pub construct: Vec<TriplePattern>,
+    /// The WHERE clause.
+    /// This clause is used to specify the triples to construct using variable bindings.
     pub r#where: WhereClause,
 }
 

--- a/docs/okp4-cognitarium.md
+++ b/docs/okp4-cognitarium.md
@@ -83,7 +83,26 @@ Returns a description of the resource identified by the provided IRI as a set of
 |`describe.format`|**[DataFormat](#dataformat)\|null**. The format in which the triples are serialized. If not provided, the default format is [Turtle](https://www.w3.org/TR/turtle/) format.|
 |`describe.query`|*(Required.) * **[DescribeQuery](#describequery)**. The query to execute.|
 
+### QueryMsg::Construct
+
+Returns the resources matching the criteria defined by the provided query as a set of RDF triples serialized in the provided format.
+
+|parameter|description|
+|----------|-----------|
+|`construct`|*(Required.) * **object**. |
+|`construct.format`|**[DataFormat](#dataformat)\|null**. The format in which the triples are serialized. If not provided, the default format is [Turtle](https://www.w3.org/TR/turtle/) format.|
+|`construct.query`|*(Required.) * **[ConstructQuery](#constructquery)**. The query to execute.|
+
 ## Responses
+
+### construct
+
+Represents the response of a [QueryMsg::Construct] query.
+
+|property|description|
+|----------|-----------|
+|`data`|*(Required.) * **[Binary](#binary)**. The data serialized in the specified format.|
+|`format`|*(Required.) * **[DataFormat](#dataformat)**. The format of the data.|
 
 ### describe
 
@@ -142,6 +161,16 @@ An RDF [blank node](https://www.w3.org/TR/rdf11-concepts/#dfn-blank-node).
 |property|description|
 |----------|-----------|
 |`blank_node`|*(Required.) * **string**. |
+
+### ConstructQuery
+
+Represents a CONSTRUCT query over the triple store, allowing to retrieve a set of triples serialized in a specific format.
+
+|property|description|
+|----------|-----------|
+|`construct`|*(Required.) * **Array&lt;[TriplePattern](#triplepattern)&gt;**. The triples to construct. If nothing is provided, the patterns from the `where` clause are used for construction.|
+|`prefixes`|*(Required.) * **Array&lt;[Prefix](#prefix)&gt;**. The prefixes used in the query.|
+|`where`|*(Required.) * **Array&lt;[WhereCondition](#wherecondition)&gt;**. The WHERE clause. This clause is used to specify the triples to construct using variable bindings.|
 
 ### DataFormat
 


### PR DESCRIPTION
Specifies the CONSTRUCT query over the triple store in the `cognitarium` smart contract as required by #327.

**Notes:**
- The specification draws significant inspiration from the [sparql #construct](https://www.w3.org/TR/sparql11-query/#construct) specification.
- The implementation should be undertaken following #304, as it introduces mechanisms that closely align with what is required for this task (at first sight).