### PR TITLE
Enhance clippy linter configuration

### DIFF
--- a/Cranky.toml
+++ b/Cranky.toml
@@ -1,15 +1,39 @@
+allow = []
+
 deny = [
-  "unsafe_code",
-  "warnings",
+  "clippy::complexity",
+  "clippy::expect_used",
+  "clippy::implicit_clone",
+  "clippy::manual_string_new",
+  "clippy::map_unwrap_or",
+  "clippy::match_same_arms",
+  "clippy::option_as_ref_deref",
+  "clippy::option_filter_map",
+  "clippy::option_map_unit_fn",
+  "clippy::or_then_unwrap",
+  "clippy::panic",
+  "clippy::range_plus_one",
+  "clippy::redundant_clone",
+  "clippy::redundant_closure_for_method_calls",
+  "clippy::semicolon_if_nothing_returned",
+  "clippy::single_match_else",
+  "clippy::unnecessary_cast",
+  "clippy::unnecessary_wraps",
+  "clippy::unused_self",
+  "clippy::unwrap_used",
+  "clippy::useless_asref",
+  "clippy::useless_conversion",
+  "clippy::useless_format",
+  "nonstandard-style",
   "rust_2018_idioms",
+  "rust-2021-compatibility",
   "trivial_casts",
   "trivial_numeric_casts",
-  "unused_lifetimes",
+  "unsafe_code",
   "unused_import_braces",
+  "unused_lifetimes",
   "unused_qualifications",
-  "unused_qualifications",
+  "warnings",
 ]
 
 warn = []
-
-allow = []

--- a/Cranky.toml
+++ b/Cranky.toml
@@ -1,0 +1,15 @@
+deny = [
+  "unsafe_code",
+  "warnings",
+  "rust_2018_idioms",
+  "trivial_casts",
+  "trivial_numeric_casts",
+  "unused_lifetimes",
+  "unused_import_braces",
+  "unused_qualifications",
+  "unused_qualifications",
+]
+
+warn = []
+
+allow = []

--- a/Makefile.toml
+++ b/Makefile.toml
@@ -11,17 +11,7 @@ dependencies = ["install-rustfmt"]
 description = "Check format of sources files."
 
 [tasks.lint-rust]
-args = [
-  "clippy",
-  "--workspace",
-  "--locked",
-  "--all-targets",
-  "--",
-  "-D",
-  "clippy::all",
-  "-D",
-  "warnings",
-]
+args = ["cranky"]
 command = "cargo"
 dependencies = ["install-clippy"]
 description = "Check lint of all sources files."
@@ -512,6 +502,10 @@ install_crate = { rustup_component_name = "llvm-tools-preview" }
 
 [tasks.install-clippy]
 install_crate = { rustup_component_name = "clippy" }
+
+[tasks.intall-cranky]
+dependencies = ["install-clippy"]
+install_crate = { crate_name = "cranky" }
 
 [tasks.install-rustfmt]
 install_crate = { rustup_component_name = "rustfmt" }

--- a/contracts/okp4-cognitarium/src/querier/engine.rs
+++ b/contracts/okp4-cognitarium/src/querier/engine.rs
@@ -47,7 +47,7 @@ impl<'a> QueryEngine<'a> {
         })
     }
 
-    pub fn eval_plan(&'a self, plan: QueryPlan) -> ResolvedVariablesIterator {
+    pub fn eval_plan(&'a self, plan: QueryPlan) -> ResolvedVariablesIterator<'_> {
         return self.eval_node(plan.entrypoint)(ResolvedVariables::with_capacity(
             plan.variables.len(),
         ));

--- a/contracts/okp4-cognitarium/src/querier/plan.rs
+++ b/contracts/okp4-cognitarium/src/querier/plan.rs
@@ -77,16 +77,14 @@ impl QueryNode {
                 predicate.lookup_bound_variable(callback);
                 object.lookup_bound_variable(callback);
             }
-            QueryNode::CartesianProductJoin { left, right } => {
+            QueryNode::CartesianProductJoin { left, right }
+            | QueryNode::ForLoopJoin { left, right } => {
                 left.lookup_bound_variables(callback);
                 right.lookup_bound_variables(callback);
             }
-            QueryNode::ForLoopJoin { left, right } => {
-                left.lookup_bound_variables(callback);
-                right.lookup_bound_variables(callback);
+            QueryNode::Skip { child, .. } | QueryNode::Limit { child, .. } => {
+                child.lookup_bound_variables(callback);
             }
-            QueryNode::Skip { child, .. } => child.lookup_bound_variables(callback),
-            QueryNode::Limit { child, .. } => child.lookup_bound_variables(callback),
         }
     }
 }

--- a/contracts/okp4-cognitarium/src/querier/plan_builder.rs
+++ b/contracts/okp4-cognitarium/src/querier/plan_builder.rs
@@ -314,6 +314,12 @@ mod test {
                 }),
             ),
             (
+                IRI::Prefixed("resource".to_string()),
+                Err(StdError::generic_err(
+                    "Malformed prefixed IRI: no prefix delimiter found",
+                )),
+            ),
+            (
                 IRI::Prefixed("okp5:resource".to_string()),
                 Err(StdError::generic_err(
                     "Malformed prefixed IRI: prefix not found",

--- a/contracts/okp4-cognitarium/src/querier/plan_builder.rs
+++ b/contracts/okp4-cognitarium/src/querier/plan_builder.rs
@@ -47,7 +47,7 @@ impl<'a> PlanBuilder<'a> {
             })
             .collect::<StdResult<Vec<QueryNode>>>()?;
 
-        self.build_from_bgp(bgp)
+        Self::build_from_bgp(bgp)
             .map(|mut node| {
                 if let Some(skip) = self.skip {
                     node = QueryNode::Skip {
@@ -72,7 +72,7 @@ impl<'a> PlanBuilder<'a> {
             })
     }
 
-    fn build_from_bgp(&self, bgp: Vec<QueryNode>) -> StdResult<QueryNode> {
+    fn build_from_bgp(bgp: Vec<QueryNode>) -> StdResult<QueryNode> {
         bgp.into_iter()
             .reduce(|left: QueryNode, right: QueryNode| -> QueryNode {
                 if left
@@ -91,8 +91,10 @@ impl<'a> PlanBuilder<'a> {
                     right: Box::new(right),
                 }
             })
-            .map(Ok)
-            .unwrap_or_else(|| Err(StdError::generic_err("Empty basic graph pattern")))
+            .map_or_else(
+                || Err(StdError::generic_err("Empty basic graph pattern")),
+                Ok,
+            )
     }
 
     fn build_triple_pattern(&mut self, pattern: &TriplePattern) -> StdResult<QueryNode> {
@@ -156,24 +158,28 @@ impl<'a> PlanBuilder<'a> {
         match value {
             IRI::Prefixed(prefixed) => prefixed
                 .rfind(':')
-                .map(Ok)
-                .unwrap_or_else(|| {
-                    Err(StdError::generic_err(
-                        "Malformed prefixed IRI: no prefix delimiter found",
-                    ))
-                })
+                .map_or_else(
+                    || {
+                        Err(StdError::generic_err(
+                            "Malformed prefixed IRI: no prefix delimiter found",
+                        ))
+                    },
+                    Ok,
+                )
                 .and_then(|index| {
                     self.prefixes
                         .get(&prefixed.as_str()[..index])
                         .map(|resolved_prefix| {
                             [resolved_prefix, &prefixed.as_str()[index + 1..]].join("")
                         })
-                        .map(Ok)
-                        .unwrap_or_else(|| {
-                            Err(StdError::generic_err(
-                                "Malformed prefixed IRI: prefix not found",
-                            ))
-                        })
+                        .map_or_else(
+                            || {
+                                Err(StdError::generic_err(
+                                    "Malformed prefixed IRI: prefix not found",
+                                ))
+                            },
+                            Ok,
+                        )
                 }),
             IRI::Full(full) => Ok(full),
         }

--- a/contracts/okp4-cognitarium/src/querier/variable.rs
+++ b/contracts/okp4-cognitarium/src/querier/variable.rs
@@ -31,12 +31,12 @@ impl ResolvedVariable {
             ResolvedVariable::Predicate(p) => p.clone(),
             ResolvedVariable::Object(o) => match o {
                 Object::Named(node) => node.clone(),
-                Object::Blank(_) => None?,
-                Object::Literal(_) => None?,
+                Object::Blank(_) | Object::Literal(_) => None?,
             },
         })
     }
 
+    #[allow(clippy::unnecessary_wraps)]
     pub fn as_object(&self) -> Option<Object> {
         Some(match self {
             ResolvedVariable::Subject(s) => match s {
@@ -132,7 +132,7 @@ impl ResolvedVariables {
     }
 
     pub fn set(&mut self, index: usize, var: ResolvedVariable) {
-        self.variables[index] = Some(var)
+        self.variables[index] = Some(var);
     }
 
     pub fn get(&self, index: usize) -> &Option<ResolvedVariable> {

--- a/contracts/okp4-cognitarium/src/rdf/atom.rs
+++ b/contracts/okp4-cognitarium/src/rdf/atom.rs
@@ -15,8 +15,7 @@ pub enum Subject {
 impl fmt::Display for Subject {
     fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
         match self {
-            Subject::NamedNode(s) => write!(f, "{s}"),
-            Subject::BlankNode(s) => write!(f, "{s}"),
+            Subject::NamedNode(s) | Subject::BlankNode(s) => write!(f, "{s}"),
         }
     }
 }
@@ -42,9 +41,7 @@ pub enum Value {
 impl fmt::Display for Value {
     fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
         match self {
-            Value::NamedNode(s) => write!(f, "{s}"),
-            Value::BlankNode(s) => write!(f, "{s}"),
-            Value::LiteralSimple(s) => write!(f, "{s}"),
+            Value::NamedNode(s) | Value::BlankNode(s) | Value::LiteralSimple(s) => write!(f, "{s}"),
             Value::LiteralLang(s, l) => write!(f, "{s}@{l}"),
             Value::LiteralDatatype(s, d) => write!(f, "{s}^^{d}"),
         }
@@ -59,7 +56,7 @@ pub struct Atom {
 }
 
 impl std::fmt::Display for Atom {
-    fn fmt(&self, fmt: &mut std::fmt::Formatter) -> std::fmt::Result {
+    fn fmt(&self, fmt: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
         fmt.write_str(&format!(
             "<{}> <{}> '{}'",
             self.subject, self.property, self.value
@@ -72,16 +69,14 @@ impl<'a> From<&'a Atom> for Triple<'a> {
     fn from(atom: &'a Atom) -> Self {
         Triple {
             subject: match &atom.subject {
-                Subject::NamedNode(s) => NamedNode { iri: s.as_str() },
-                Subject::BlankNode(s) => NamedNode { iri: s.as_str() },
+                Subject::NamedNode(s) | Subject::BlankNode(s) => NamedNode { iri: s.as_str() },
             }
             .into(),
             predicate: NamedNode {
                 iri: atom.property.0.as_str(),
             },
             object: match &atom.value {
-                Value::NamedNode(s) => NamedNode { iri: s.as_str() }.into(),
-                Value::BlankNode(s) => NamedNode { iri: s.as_str() }.into(),
+                Value::NamedNode(s) | Value::BlankNode(s) => NamedNode { iri: s.as_str() }.into(),
                 Value::LiteralSimple(s) => Literal::Simple { value: s.as_str() }.into(),
                 Value::LiteralLang(s, l) => Literal::LanguageTaggedString {
                     value: s.as_str(),

--- a/contracts/okp4-cognitarium/src/rdf/serde.rs
+++ b/contracts/okp4-cognitarium/src/rdf/serde.rs
@@ -46,7 +46,7 @@ impl<R: BufRead> TripleReader<R> {
 
     pub fn read_all<E, UF>(&mut self, mut use_fn: UF) -> Result<(), E>
     where
-        UF: FnMut(Triple) -> Result<(), E>,
+        UF: FnMut(Triple<'_>) -> Result<(), E>,
         E: From<TurtleError> + From<RdfXmlError>,
     {
         match &mut self.parser {
@@ -54,7 +54,7 @@ impl<R: BufRead> TripleReader<R> {
             TriplesParserKind::Turtle(parser) => parser.parse_all(&mut use_fn),
             TriplesParserKind::RdfXml(parser) => parser.parse_all(&mut use_fn),
             TriplesParserKind::NQuads(parser) => {
-                parser.parse_all(&mut |quad: Quad| -> Result<(), E> {
+                parser.parse_all(&mut |quad: Quad<'_>| -> Result<(), E> {
                     use_fn(Triple {
                         subject: quad.subject,
                         predicate: quad.predicate,

--- a/contracts/okp4-cognitarium/src/rdf/uri.rs
+++ b/contracts/okp4-cognitarium/src/rdf/uri.rs
@@ -14,7 +14,7 @@ pub fn explode_iri(iri: &str) -> StdResult<(String, String)> {
     }
 
     if let Some(index) = marker_index {
-        return Ok((iri[..index + 1].to_string(), iri[index + 1..].to_string()));
+        return Ok((iri[..=index].to_string(), iri[index + 1..].to_string()));
     }
 
     Err(StdError::generic_err("Couldn't extract IRI namespace"))

--- a/contracts/okp4-cognitarium/src/state/namespaces.rs
+++ b/contracts/okp4-cognitarium/src/state/namespaces.rs
@@ -3,7 +3,7 @@ use serde::{Deserialize, Serialize};
 
 /// Store a key increment used a unique key for referencing a namespace. Given the size of an `u128`
 /// there is no need to implement a garbage collector mechanism in case some namespaces are removed.
-pub const NAMESPACE_KEY_INCREMENT: Item<u128> = Item::new("namespace_key");
+pub const NAMESPACE_KEY_INCREMENT: Item<'_, u128> = Item::new("namespace_key");
 
 #[derive(Serialize, Deserialize, Clone, Debug, PartialEq, Eq)]
 pub struct Namespace {
@@ -23,7 +23,8 @@ pub struct NamespaceIndexes<'a> {
 
 impl IndexList<Namespace> for NamespaceIndexes<'_> {
     fn get_indexes(&self) -> Box<dyn Iterator<Item = &'_ dyn Index<Namespace>> + '_> {
-        Box::new(vec![&self.key as &dyn Index<Namespace>].into_iter())
+        let key: &dyn Index<Namespace> = &self.key;
+        Box::new(vec![key].into_iter())
     }
 }
 

--- a/contracts/okp4-cognitarium/src/state/store.rs
+++ b/contracts/okp4-cognitarium/src/state/store.rs
@@ -4,7 +4,7 @@ use cosmwasm_std::{Addr, Uint128};
 use cw_storage_plus::Item;
 use serde::{Deserialize, Serialize};
 
-pub const STORE: Item<Store> = Item::new("store");
+pub const STORE: Item<'_, Store> = Item::new("store");
 
 #[derive(Serialize, Deserialize, Clone, Debug, PartialEq, Eq)]
 pub struct Store {

--- a/contracts/okp4-cognitarium/src/state/triples.rs
+++ b/contracts/okp4-cognitarium/src/state/triples.rs
@@ -15,7 +15,8 @@ pub struct TripleIndexes<'a> {
 
 impl IndexList<Triple> for TripleIndexes<'_> {
     fn get_indexes(&self) -> Box<dyn Iterator<Item = &'_ dyn Index<Triple>> + '_> {
-        Box::new(vec![&self.subject_and_predicate as &dyn Index<Triple>].into_iter())
+        let subject_and_predicate: &dyn Index<Triple> = &self.subject_and_predicate;
+        Box::new(vec![subject_and_predicate].into_iter())
     }
 }
 
@@ -133,7 +134,7 @@ impl Node {
     where
         F: FnMut(u128) -> StdResult<String>,
     {
-        ns_fn(self.namespace).map(|ns| vec![ns.as_str(), self.value.as_str()].join(""))
+        ns_fn(self.namespace).map(|ns| [ns.as_str(), self.value.as_str()].join(""))
     }
 }
 

--- a/contracts/okp4-law-stone/src/contract.rs
+++ b/contracts/okp4-law-stone/src/contract.rs
@@ -153,7 +153,7 @@ pub mod query {
         let program_uri = object_ref_to_uri(program)?.to_string();
 
         Ok(LogicCustomQuery::Ask {
-            program: "".to_string(),
+            program: String::new(),
             query: ["consult('", program_uri.as_str(), "'), ", query.as_str()].join(""),
         })
     }

--- a/contracts/okp4-objectarium/src/compress.rs
+++ b/contracts/okp4-objectarium/src/compress.rs
@@ -62,6 +62,7 @@ impl From<lzma_rs::error::Error> for CompressionError {
 
 /// pass_through returns the data as is.
 #[inline]
+#[allow(clippy::unnecessary_wraps)]
 fn passthrough(data: &[u8]) -> Result<Vec<u8>, CompressionError> {
     Ok(data.to_vec())
 }

--- a/contracts/okp4-objectarium/src/crypto.rs
+++ b/contracts/okp4-objectarium/src/crypto.rs
@@ -113,7 +113,7 @@ impl<'a> PrimaryKey<'a> for Hash {
     type Suffix = Self;
     type SuperSuffix = Self;
 
-    fn key(&self) -> Vec<Key> {
+    fn key(&self) -> Vec<Key<'_>> {
         vec![Key::Ref(self.0.as_ref())]
     }
 }
@@ -137,7 +137,7 @@ impl KeyDeserialize for &Hash {
 }
 
 impl<'a> Prefixer<'a> for Hash {
-    fn prefix(&self) -> Vec<Key> {
+    fn prefix(&self) -> Vec<Key<'_>> {
         vec![Key::Ref(self.0.as_ref())]
     }
 }

--- a/contracts/okp4-objectarium/src/cursor.rs
+++ b/contracts/okp4-objectarium/src/cursor.rs
@@ -28,7 +28,7 @@ impl AsCursor<Hash> for Object {
     fn decode_cursor(cursor: Cursor) -> StdResult<Hash> {
         bs58::decode(cursor)
             .into_vec()
-            .map(|e| e.into())
+            .map(Into::into)
             .map_err(|err| StdError::parse_err("Cursor", err))
     }
 }

--- a/contracts/okp4-objectarium/src/state.rs
+++ b/contracts/okp4-objectarium/src/state.rs
@@ -9,7 +9,7 @@ use cw_storage_plus::{Index, IndexList, IndexedMap, Item, Map, MultiIndex};
 use schemars::JsonSchema;
 use serde::{Deserialize, Serialize};
 
-pub const DATA: Map<Hash, Vec<u8>> = Map::new("DATA");
+pub const DATA: Map<'_, Hash, Vec<u8>> = Map::new("DATA");
 
 #[derive(Serialize, Deserialize, Clone, Debug, PartialEq, Eq, JsonSchema)]
 pub struct Bucket {
@@ -254,7 +254,7 @@ impl TryFrom<PaginationConfig> for Pagination {
     }
 }
 
-pub const BUCKET: Item<Bucket> = Item::new("bucket");
+pub const BUCKET: Item<'_, Bucket> = Item::new("bucket");
 
 #[derive(Serialize, Deserialize, Clone, Debug, PartialEq, Eq, JsonSchema)]
 pub struct Object {
@@ -291,7 +291,8 @@ pub struct ObjectIndexes<'a> {
 
 impl IndexList<Object> for ObjectIndexes<'_> {
     fn get_indexes(&'_ self) -> Box<dyn Iterator<Item = &'_ dyn Index<Object>> + '_> {
-        Box::new(vec![&self.owner as &dyn Index<Object>].into_iter())
+        let owner: &dyn Index<Object> = &self.owner;
+        Box::new(vec![owner].into_iter())
     }
 }
 
@@ -318,7 +319,8 @@ pub struct PinIndexes<'a> {
 
 impl IndexList<Pin> for PinIndexes<'_> {
     fn get_indexes(&'_ self) -> Box<dyn Iterator<Item = &'_ dyn Index<Pin>> + '_> {
-        Box::new(vec![&self.object as &dyn Index<Pin>].into_iter())
+        let object: &dyn Index<Pin> = &self.object;
+        Box::new(vec![object].into_iter())
     }
 }
 

--- a/packages/okp4-logic-bindings/src/term_parser.rs
+++ b/packages/okp4-logic-bindings/src/term_parser.rs
@@ -88,7 +88,7 @@ impl<'a> Parser<'a> {
         loop {
             match self.peek() {
                 Some(t) if [b'[', b'(', b'\'', b'"', b' '].contains(&t) => {
-                    Err(TermParseError::UnexpectedValueToken(char::from(t)))?
+                    Err(TermParseError::UnexpectedValueToken(char::from(t)))?;
                 }
                 Some(b) if ![b']', b')', b','].contains(&b) => {
                     self.eat_char();
@@ -178,8 +178,7 @@ impl<'a> Parser<'a> {
         }
 
         if values.len() == 1 {
-            let val = values.first().unwrap();
-            return Ok(val.clone());
+            return Ok(values[0].clone());
         }
 
         Ok(TermValue::Tuple(values))

--- a/packages/okp4-logic-bindings/src/testing/mock.rs
+++ b/packages/okp4-logic-bindings/src/testing/mock.rs
@@ -45,6 +45,6 @@ impl LogicQuerier {
     where
         LH: Fn(&LogicCustomQuery) -> QuerierResult,
     {
-        self.handler = Box::from(handler)
+        self.handler = Box::from(handler);
     }
 }


### PR DESCRIPTION
This PR aims to enhance the code quality of the smart contracts by standardizing the configuration of the Clippy linter in use. Previously, the configuration was inconsistently applied across the various crates of the project, leading to inconsistent code quality. This PR introduces the following changes:
- Uses [Cranky](https://github.com/ericseppanen/cargo-cranky) to streamline and ensure the uniform application of Clippy's configuration across all project crates,
- Stricter Clippy configuration to improve overall code quality.

The code has been updated accordingly. Coverage has decreased very slightly, but I don't think this has any impact given the nature of the changes, which are stylistic.