### PR TITLE
chore: update @fadroma/schema to 1.1.0

### DIFF
--- a/Makefile.toml
+++ b/Makefile.toml
@@ -113,6 +113,7 @@ find contracts/*/schema -type f -maxdepth 1 -name '*.json' \
 mkdir -p $DOCS_FOLDER
 
 for SCHEMA in $(ls $SCHEMA_FOLDER); do
+    echo "Rendering $SCHEMA..."
     awk "{sub(\"#/definitions\",\"./${SCHEMA}/#/definitions\")} {print}"  ${SCHEMA_FOLDER}/${SCHEMA} > ${SCHEMA_FOLDER}/tmp
 
     npx --yes @fadroma/schema@1.1.0 ${SCHEMA_FOLDER}/tmp > "${SCHEMA%.json}.md"

--- a/Makefile.toml
+++ b/Makefile.toml
@@ -115,7 +115,7 @@ mkdir -p $DOCS_FOLDER
 for SCHEMA in $(ls $SCHEMA_FOLDER); do
     awk "{sub(\"#/definitions\",\"./${SCHEMA}/#/definitions\")} {print}"  ${SCHEMA_FOLDER}/${SCHEMA} > ${SCHEMA_FOLDER}/tmp
 
-    npx --yes @fadroma/schema@1.0.6 ${SCHEMA_FOLDER}/tmp > "${SCHEMA%.json}.md"
+    npx --yes @fadroma/schema@1.1.0 ${SCHEMA_FOLDER}/tmp > "${SCHEMA%.json}.md"
 
     mv "${SCHEMA%.json}.md" "docs/${SCHEMA%.json}.md"
 done

--- a/docs/okp4-cognitarium.md
+++ b/docs/okp4-cognitarium.md
@@ -475,3 +475,7 @@ Represents a condition in a [WhereClause].
 |variant|description|
 |-------|-----------|
 |[Simple](#simple)|**object**. Represents a simple condition.|
+
+---
+
+*Rendered by [Fadroma](https://fadroma.tech) ([@fadroma/schema 1.1.0](https://www.npmjs.com/package/@fadroma/schema)) from `tmp` (`9967756b93791148`)*

--- a/docs/okp4-law-stone.md
+++ b/docs/okp4-law-stone.md
@@ -123,3 +123,7 @@ A string containing Base64-encoded data.
 |----------|-----------|
 |`arguments`|*(Required.) * **Array&lt;[Term](#term)&gt;**. |
 |`name`|*(Required.) * **string**. |
+
+---
+
+*Rendered by [Fadroma](https://fadroma.tech) ([@fadroma/schema 1.1.0](https://www.npmjs.com/package/@fadroma/schema)) from `tmp` (`20c06a648259a4b3`)*

--- a/docs/okp4-objectarium.md
+++ b/docs/okp4-objectarium.md
@@ -468,3 +468,7 @@ A string containing a 128-bit integer in decimal representation.
 |type|
 |----|
 |**string**.|
+
+---
+
+*Rendered by [Fadroma](https://fadroma.tech) ([@fadroma/schema 1.1.0](https://www.npmjs.com/package/@fadroma/schema)) from `tmp` (`8624f6ec32a56a5d`)*


### PR DESCRIPTION
This adds a footer to generated docs which contains:

* Name of schema file used to generate schema
* First 16 characters of SHA256 hash of source schema file
* Link to https://www.npmjs.com/package/@fadroma/schema and version used
* Link to https://fadroma.tech/

I hope the latter two are acceptable. We're trying to raise awareness of our toolkit's existence, and would be happy to collaborate more closely with your team in the future.