### PR TITLE
ci(lint): fix cosmwasm-check version

### DIFF
--- a/Makefile.toml
+++ b/Makefile.toml
@@ -522,7 +522,7 @@ install_crate = { crate_name = "taplo-cli", binary = "taplo", test_arg = "--help
 install_crate = { crate_name = "cargo-llvm-cov" }
 
 [tasks.install-cosmwasm-check]
-install_crate = { crate_name = "cosmwasm-check" }
+install_crate = { crate_name = "cosmwasm-check", min_version = "1.2.7" }
 
 [tasks.install-ffizer]
 install_script = '''
@@ -537,6 +537,8 @@ default_to_workspace = false
 min_version = "0.36.3"
 
 [env]
+CARGO_MAKE_CRATE_INSTALLATION_LOCKED = true
+
 DOCS_FOLDER = "docs"
 SCHEMA_FOLDER = "schema"
 


### PR DESCRIPTION
## Purpose

In order to ensure that produced contracts codes are compatible with wasm vm used by [okp4d](https://github.com/okp4/okp4d) this PR come the fix the `cosmwasm-check` linter version. The version here is fixed to `v1.2.7` which corresponds to the [v1.2.4 wasmvm](https://github.com/CosmWasm/wasmvm/releases/tag/v1.2.4) version currently embedded in OKP4 nodes.

## Remarks

The current contracts are built using cosmwasm `v1.3.3` but this isn't an issue as features leveraging wasmvm `v1.3.0` specific bindings needs the build flag `cosmwasm_1_3`.

The `cosmwasm-check` linter version shall be updated to follow the OKP4 node vm version.