### PR TITLE
docs(cognitarium): update docs to latest schema

### DIFF
--- a/Makefile.toml
+++ b/Makefile.toml
@@ -114,9 +114,10 @@ mkdir -p $DOCS_FOLDER
 
 for SCHEMA in $(ls $SCHEMA_FOLDER); do
     echo "Rendering $SCHEMA..."
-    awk "{sub(\"#/definitions\",\"./${SCHEMA}/#/definitions\")} {print}"  ${SCHEMA_FOLDER}/${SCHEMA} > ${SCHEMA_FOLDER}/tmp
+    awk "{sub(\"#/definitions\",\"./${SCHEMA}/#/definitions\")} {print}"  ${SCHEMA_FOLDER}/${SCHEMA} > ${SCHEMA_FOLDER}/${SCHEMA}.tmp
+    mv ${SCHEMA_FOLDER}/${SCHEMA}.tmp ${SCHEMA_FOLDER}/${SCHEMA}
 
-    npx --yes @fadroma/schema@1.1.0 ${SCHEMA_FOLDER}/tmp > "${SCHEMA%.json}.md"
+    npx --yes @fadroma/schema@1.1.0 ${SCHEMA_FOLDER}/${SCHEMA} > "${SCHEMA%.json}.md"
 
     mv "${SCHEMA%.json}.md" "docs/${SCHEMA%.json}.md"
 done

--- a/docs/okp4-cognitarium.md
+++ b/docs/okp4-cognitarium.md
@@ -478,4 +478,4 @@ Represents a condition in a [WhereClause].
 
 ---
 
-*Rendered by [Fadroma](https://fadroma.tech) ([@fadroma/schema 1.1.0](https://www.npmjs.com/package/@fadroma/schema)) from `tmp` (`9967756b93791148`)*
+*Rendered by [Fadroma](https://fadroma.tech) ([@fadroma/schema 1.1.0](https://www.npmjs.com/package/@fadroma/schema)) from `tmp` (`889a2c1536ecfea5`)*

--- a/docs/okp4-cognitarium.md
+++ b/docs/okp4-cognitarium.md
@@ -478,4 +478,4 @@ Represents a condition in a [WhereClause].
 
 ---
 
-*Rendered by [Fadroma](https://fadroma.tech) ([@fadroma/schema 1.1.0](https://www.npmjs.com/package/@fadroma/schema)) from `tmp` (`889a2c1536ecfea5`)*
+*Rendered by [Fadroma](https://fadroma.tech) ([@fadroma/schema 1.1.0](https://www.npmjs.com/package/@fadroma/schema)) from `okp4-cognitarium.json` (`889a2c1536ecfea5`)*

--- a/docs/okp4-law-stone.md
+++ b/docs/okp4-law-stone.md
@@ -126,4 +126,4 @@ A string containing Base64-encoded data.
 
 ---
 
-*Rendered by [Fadroma](https://fadroma.tech) ([@fadroma/schema 1.1.0](https://www.npmjs.com/package/@fadroma/schema)) from `tmp` (`20c06a648259a4b3`)*
+*Rendered by [Fadroma](https://fadroma.tech) ([@fadroma/schema 1.1.0](https://www.npmjs.com/package/@fadroma/schema)) from `okp4-law-stone.json` (`20c06a648259a4b3`)*

--- a/docs/okp4-objectarium.md
+++ b/docs/okp4-objectarium.md
@@ -471,4 +471,4 @@ A string containing a 128-bit integer in decimal representation.
 
 ---
 
-*Rendered by [Fadroma](https://fadroma.tech) ([@fadroma/schema 1.1.0](https://www.npmjs.com/package/@fadroma/schema)) from `tmp` (`8624f6ec32a56a5d`)*
+*Rendered by [Fadroma](https://fadroma.tech) ([@fadroma/schema 1.1.0](https://www.npmjs.com/package/@fadroma/schema)) from `okp4-objectarium.json` (`8624f6ec32a56a5d`)*


### PR DESCRIPTION
Since `cognitarium` schema has been updated, need to update docs.

To make the docs footer more clean, I've improved the `docs-generate` task to name the schema file that is used to generate documentation, it avoid indicate that the docs has been generated through a `tmp` file. FYI @egasimus. 