### PR TITLE
refactor(cognitarium): namespace handling

### DIFF
--- a/contracts/okp4-cognitarium/src/contract.rs
+++ b/contracts/okp4-cognitarium/src/contract.rs
@@ -188,7 +188,8 @@ pub mod query {
         }
 
         let prefix_map = PrefixMap::from(query.prefixes).into_inner();
-        let plan = PlanBuilder::new(deps.storage, &prefix_map)
+        let plan_builder = PlanBuilder::new(deps.storage, &prefix_map);
+        let plan = plan_builder
             .with_limit(count as usize)
             .build_plan(&query.r#where)?;
 

--- a/contracts/okp4-cognitarium/src/querier/engine.rs
+++ b/contracts/okp4-cognitarium/src/querier/engine.rs
@@ -390,9 +390,7 @@ impl<'a> SolutionsIterator<'a> {
     ) -> Self {
         Self {
             storage,
-            ns_resolver: ns_cache
-                .map(Into::into)
-                .unwrap_or_else(NamespaceResolver::new),
+            ns_resolver: ns_cache.map_or_else(NamespaceResolver::new, Into::into),
             iter,
             bindings,
         }
@@ -405,7 +403,7 @@ impl<'a> HasCachedNamespaces for SolutionsIterator<'a> {
     }
 
     fn clear_cache(&mut self) {
-        self.ns_resolver.clear_cache()
+        self.ns_resolver.clear_cache();
     }
 }
 

--- a/contracts/okp4-cognitarium/src/querier/plan_builder.rs
+++ b/contracts/okp4-cognitarium/src/querier/plan_builder.rs
@@ -203,7 +203,7 @@ mod test {
     use super::*;
     use crate::msg::Prefix;
     use crate::rdf::PrefixMap;
-    use crate::state::Namespace;
+    use crate::state::{namespaces, Namespace};
     use cosmwasm_std::testing::mock_dependencies;
 
     #[test]

--- a/contracts/okp4-cognitarium/src/querier/plan_builder.rs
+++ b/contracts/okp4-cognitarium/src/querier/plan_builder.rs
@@ -4,9 +4,7 @@ use crate::msg::{
 };
 use crate::querier::plan::{PatternValue, QueryNode, QueryPlan};
 use crate::rdf::expand_uri;
-use crate::state::{
-    namespaces, HasCachedNamespaces, Namespace, NamespaceResolver, Object, Predicate, Subject,
-};
+use crate::state::{HasCachedNamespaces, Namespace, NamespaceResolver, Object, Predicate, Subject};
 use crate::{rdf, state};
 use cosmwasm_std::{StdError, StdResult, Storage};
 use std::collections::HashMap;
@@ -28,9 +26,7 @@ impl<'a> PlanBuilder<'a> {
     ) -> Self {
         Self {
             storage,
-            ns_resolver: ns_cache
-                .map(Into::into)
-                .unwrap_or_else(NamespaceResolver::new),
+            ns_resolver: ns_cache.map_or_else(NamespaceResolver::new, Into::into),
             prefixes,
             variables: Vec::new(),
             skip: None,
@@ -198,7 +194,7 @@ impl<'a> HasCachedNamespaces for PlanBuilder<'a> {
     }
 
     fn clear_cache(&mut self) {
-        self.ns_resolver.clear_cache()
+        self.ns_resolver.clear_cache();
     }
 }
 

--- a/contracts/okp4-cognitarium/src/state/namespaces.rs
+++ b/contracts/okp4-cognitarium/src/state/namespaces.rs
@@ -69,6 +69,11 @@ impl<'a> NamespaceResolver<'a> {
             .map(|maybe_cell| maybe_cell.map(|cell| cell.borrow().clone()))
     }
 
+    pub fn clear(&mut self) -> () {
+        self.by_val.clear();
+        self.by_key.clear();
+    }
+
     fn resolve_cell_from_val(
         &mut self,
         value: String,
@@ -170,7 +175,7 @@ impl<'a> NamespaceBatchService<'a> {
             }
         }
 
-        Ok(self.ns_count_diff)
+        self.Ok(self.ns_count_diff)
     }
 
     fn allocate(&mut self, value: String) -> Namespace {

--- a/contracts/okp4-cognitarium/src/state/namespaces.rs
+++ b/contracts/okp4-cognitarium/src/state/namespaces.rs
@@ -64,6 +64,11 @@ impl<'a> NamespaceResolver<'a> {
             .map(|maybe_cell| maybe_cell.map(|cell| cell.borrow().clone()))
     }
 
+    pub fn resolve_from_key(&mut self, key: u128) -> StdResult<Option<Namespace>> {
+        self.resolve_cell_from_key(key)
+            .map(|maybe_cell| maybe_cell.map(|cell| cell.borrow().clone()))
+    }
+
     fn resolve_cell_from_val(
         &mut self,
         value: String,
@@ -75,6 +80,18 @@ impl<'a> NamespaceResolver<'a> {
         namespaces()
             .may_load(self.storage, value)
             .map(|maybe_ns| maybe_ns.map(|ns| self.insert(ns)))
+    }
+
+    fn resolve_cell_from_key(&mut self, key: u128) -> StdResult<Option<Rc<RefCell<Namespace>>>> {
+        if let Some(rc) = self.by_key.get(&key) {
+            return Ok(Some(rc.clone()));
+        }
+
+        namespaces()
+            .idx
+            .key
+            .item(self.storage, key)
+            .map(|maybe_ns| maybe_ns.map(|ns| self.insert(ns.1)))
     }
 
     fn insert(&mut self, ns: Namespace) -> Rc<RefCell<Namespace>> {

--- a/contracts/okp4-cognitarium/src/state/namespaces.rs
+++ b/contracts/okp4-cognitarium/src/state/namespaces.rs
@@ -175,7 +175,11 @@ impl<'a> NamespaceBatchService<'a> {
             }
         }
 
-        self.Ok(self.ns_count_diff)
+        let count_diff = self.ns_count_diff;
+        self.ns_count_diff = 0;
+        self.ns_resolver.clear();
+
+        Ok(count_diff)
     }
 
     fn allocate(&mut self, value: String) -> Namespace {

--- a/contracts/okp4-cognitarium/src/state/namespaces.rs
+++ b/contracts/okp4-cognitarium/src/state/namespaces.rs
@@ -59,6 +59,24 @@ impl<'a> NamespaceResolver<'a> {
         }
     }
 
+    pub fn resolve_from_val(&mut self, value: String) -> StdResult<Option<Namespace>> {
+        self.resolve_cell_from_val(value)
+            .map(|maybe_cell| maybe_cell.map(|cell| cell.borrow().clone()))
+    }
+
+    fn resolve_cell_from_val(
+        &mut self,
+        value: String,
+    ) -> StdResult<Option<Rc<RefCell<Namespace>>>> {
+        if let Some(rc) = self.by_val.get(value.as_str()) {
+            return Ok(Some(rc.clone()));
+        }
+
+        namespaces()
+            .may_load(self.storage, value)
+            .map(|maybe_ns| maybe_ns.map(|ns| self.insert(ns)))
+    }
+
     fn insert(&mut self, ns: Namespace) -> Rc<RefCell<Namespace>> {
         let ns_rc = Rc::new(RefCell::new(ns.clone()));
 

--- a/contracts/okp4-cognitarium/src/state/namespaces.rs
+++ b/contracts/okp4-cognitarium/src/state/namespaces.rs
@@ -69,7 +69,7 @@ impl<'a> NamespaceResolver<'a> {
             .map(|maybe_cell| maybe_cell.map(|cell| cell.borrow().clone()))
     }
 
-    pub fn clear(&mut self) -> () {
+    pub fn clear(&mut self) {
         self.by_val.clear();
         self.by_key.clear();
     }
@@ -106,6 +106,13 @@ impl<'a> NamespaceResolver<'a> {
         self.by_key.insert(ns.key.clone(), ns_rc.clone());
 
         ns_rc
+    }
+
+    pub fn none_as_error_middleware(resolve_res: Option<Namespace>) -> StdResult<Namespace> {
+        match resolve_res {
+            Some(ns) => Ok(ns),
+            None => Err(StdError::not_found("Namespace")),
+        }
     }
 }
 


### PR DESCRIPTION
Closes #308 

Introduce components to manage the logic to resolve & manipulate namespaces with the state.

## Details

The `NamespaceResolver` offer a two way resolution mechanism (i.e. by key or by value) so it can be used in the same way by all the components needing to resolve namespaces. It implements an in-memory cache by maintaining two binary trees up to date. For efficiency purposes the in-memory stored `Namespaces` are referenced by a mutable memory location so that a change on one binary tree is effective on the other, keeping track of the references using the appropriate smart pointer.

The `NamespaceBatchService` allows to perform necessary mutations on namespaces by managing them in-memory using the `NamespaceResolver`, writing to the state the changes only when calling `flush()`.

As multiple components using namespace resolution can be put into play when serving contract messages, it seems logical to share the `NamespaceResolver` cache between them to reduce state access, this is done exporting the cache on one side and creating the new `NamespaceResolver` with it.

## Caveats

When deleting triples, the `StoreEngine` could take benefit from the namespace cache used to query the triples to delete, I chose not to use it to avoid state writes on unchanged namespaces, an improvement could be brought here in the future.