### PR TITLE
Feat/law stone program code

### DIFF
--- a/contracts/okp4-law-stone/src/contract.rs
+++ b/contracts/okp4-law-stone/src/contract.rs
@@ -123,6 +123,7 @@ pub fn query(deps: Deps<'_, LogicCustomQuery>, _env: Env, msg: QueryMsg) -> StdR
     match msg {
         QueryMsg::Ask { query } => to_binary(&query::ask(deps, query)?),
         QueryMsg::Program => to_binary(&query::program(deps)?),
+        QueryMsg::ProgramCode => to_binary(&query::program_code(deps)?),
     }
 }
 
@@ -137,6 +138,18 @@ pub mod query {
     pub fn program(deps: Deps<'_, LogicCustomQuery>) -> StdResult<ProgramResponse> {
         let program = PROGRAM.load(deps.storage)?.into();
         Ok(program)
+    }
+
+    pub fn program_code(deps: Deps<'_, LogicCustomQuery>) -> StdResult<Binary> {
+        let ObjectRef {
+            storage_address,
+            object_id,
+        } = PROGRAM.load(deps.storage)?.law;
+
+        deps.querier.query_wasm_smart::<Binary>(
+            storage_address,
+            &StorageQuery::ObjectData { id: object_id },
+        )
     }
 
     pub fn ask(deps: Deps<'_, LogicCustomQuery>, query: String) -> StdResult<AskResponse> {

--- a/contracts/okp4-law-stone/src/contract.rs
+++ b/contracts/okp4-law-stone/src/contract.rs
@@ -398,6 +398,50 @@ mod tests {
         assert_eq!(storage_addr, result.storage_address);
     }
 
+    #[test]
+    fn program_code() {
+        const CONTRACT_ID: &str = "okp41ffzp0xmjhwkltuxcvccl0z9tyfuu7txp5ke0tpkcjpzuq9fcj3pqrteqt3";
+        const OBJECT_ID: &str = "4cbe36399aabfcc7158ee7a66cbfffa525bb0ceab33d1ff2cff08759fe0a9b05";
+        const A_PROGRAM: &str = "foo(_) :- true.";
+
+        let mut deps =
+            mock_dependencies_with_logic_handler(|_| SystemResult::Err(SystemError::Unknown {}));
+        deps.querier.update_wasm(move |query| match query {
+            WasmQuery::Smart { contract_addr, msg } if contract_addr == CONTRACT_ID => {
+                let data = to_binary(&A_PROGRAM).unwrap();
+                let storage_query: StorageQuery = from_binary(msg).unwrap();
+
+                assert!(
+                    matches!(storage_query, StorageQuery::ObjectData { id } if id == OBJECT_ID)
+                );
+
+                SystemResult::Ok(ContractResult::Ok(to_binary(&data).unwrap()))
+            }
+            _ => {
+                panic!("UnsupportedRequest: query_wasm");
+            }
+        });
+
+        PROGRAM
+            .save(
+                deps.as_mut().storage,
+                &LawStone {
+                    broken: false,
+                    law: ObjectRef {
+                        object_id: OBJECT_ID.to_string(),
+                        storage_address: CONTRACT_ID.to_string(),
+                    },
+                },
+            )
+            .unwrap();
+
+        let result = query(deps.as_ref(), mock_env(), QueryMsg::ProgramCode {}).unwrap();
+        let data: Binary = from_binary(&result).unwrap();
+        let program: String = from_binary(&data).unwrap();
+
+        assert_eq!(A_PROGRAM, program);
+    }
+
     fn custom_logic_handler_with_query(
         query: String,
         program: ObjectRef,

--- a/contracts/okp4-law-stone/src/msg.rs
+++ b/contracts/okp4-law-stone/src/msg.rs
@@ -38,6 +38,11 @@ pub enum QueryMsg {
     /// If not broken, returns the law program location information.
     #[returns(ProgramResponse)]
     Program,
+
+    /// # ProgramCode
+    /// ProgramCode returns the law program code.
+    #[returns(Binary)]
+    ProgramCode,
 }
 
 /// # ProgramResponse

--- a/docs/okp4-law-stone.md
+++ b/docs/okp4-law-stone.md
@@ -56,6 +56,14 @@ If not broken, returns the law program location information.
 |-------|
 |`"program"`|
 
+### QueryMsg::ProgramCode
+
+ProgramCode returns the law program code.
+
+|literal|
+|-------|
+|`"program_code"`|
+
 ## Responses
 
 ### ask
@@ -76,6 +84,16 @@ ProgramResponse carry elements to locate the program in a `okp4-objectarium` con
 |----------|-----------|
 |`object_id`|*(Required.) * **string**. The program object id in the `okp4-objectarium` contract.|
 |`storage_address`|*(Required.) * **string**. The `okp4-objectarium` contract address on which the law program is stored.|
+
+### program_code
+
+Binary is a wrapper around Vec&lt;u8&gt; to add base64 de/serialization with serde. It also adds some helper methods to help encode inline.
+
+This is only needed as serde-json-{core,wasm} has a horrible encoding for Vec&lt;u8&gt;. See also &lt;https://github.com/CosmWasm/cosmwasm/blob/main/docs/MESSAGE_TYPES.md&gt;.
+
+|type|
+|----|
+|**string**.|
 
 ## Definitions
 
@@ -126,4 +144,4 @@ A string containing Base64-encoded data.
 
 ---
 
-*Rendered by [Fadroma](https://fadroma.tech) ([@fadroma/schema 1.1.0](https://www.npmjs.com/package/@fadroma/schema)) from `okp4-law-stone.json` (`023b72150b485c6b`)*
+*Rendered by [Fadroma](https://fadroma.tech) ([@fadroma/schema 1.1.0](https://www.npmjs.com/package/@fadroma/schema)) from `okp4-law-stone.json` (`092608edf6c36d25`)*


### PR DESCRIPTION
Implement #389.
<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
### Summary by CodeRabbit

- New Feature: Added a new functionality to retrieve the code of a law program stored within the contract's storage. This feature enhances the transparency of the system by allowing users to view the underlying code of the program.
- Documentation: Updated the documentation to reflect the new changes in the `QueryMsg` enum and the introduction of the `Binary` struct. This will help users understand the new features and how to use them effectively.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->