### PR TITLE
ci(release): add dataverse in github release assets

### DIFF
--- a/.releaserc.yml
+++ b/.releaserc.yml
@@ -24,10 +24,12 @@ plugins:
         - path: "./target/wasm32-unknown-unknown/release/okp4_objectarium.wasm"
         - path: "./target/wasm32-unknown-unknown/release/okp4_law_stone.wasm"
         - path: "./target/wasm32-unknown-unknown/release/okp4_cognitarium.wasm"
+        - path: "./target/wasm32-unknown-unknown/release/okp4_dataverse.wasm"
         - path: "./target/wasm32-unknown-unknown/release/sha256sum.txt"
         - path: "./contracts/okp4-objectarium/schema/okp4-objectarium.json"
         - path: "./contracts/okp4-law-stone/schema/okp4-law-stone.json"
         - path: "./contracts/okp4-cognitarium/schema/okp4-cognitarium.json"
+        - path: "./contracts/okp4-cognitarium/schema/okp4-dataverse.json"
   - - "@semantic-release/git"
     - assets:
         - CHANGELOG.md


### PR DESCRIPTION
The data verse contract was missing from the GitHub release assets.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Introduced a new WebAssembly module to enhance app capabilities.
  - Launched "dataverse" component for advanced data interactions.

- **Documentation**
  - Updated asset list with new module and schema details.

- **Refactor**
  - Renamed contract schema file for consistency with new feature naming.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->