### PR TITLE
Build/standardize md doc

### DIFF
--- a/Makefile.toml
+++ b/Makefile.toml
@@ -180,9 +180,13 @@ for SCHEMA in $(ls $SCHEMA_FOLDER); do
 EOF
 
     rm "docs/${to}.tmp"
+
 done
 
 rm -rf $SCHEMA_FOLDER
+
+echo "📐 Formatting documentation..."
+npx --yes prettier@3.1.1 docs/*.md --write
 
 echo "📖 Documentation has been successfully generated and available at $(pwd)/$DOCS_FOLDER/README.md"
 '''

--- a/Makefile.toml
+++ b/Makefile.toml
@@ -87,19 +87,44 @@ echo "🧹 Cleaning documentation folder"
 rm -rf ${DOCS_FOLDER}/*
 '''
 
-[tasks.docs-generate]
-dependencies = ["docs-clean", "schema"]
-description = "Generate documentation"
+[tasks.check-prerequisites]
+description = "Check prerequisites"
 script = '''
-echo "🔎 Checking \`npx\` installed..."
+echo "🔍 Checking prerequisites"
+
+echo "❔ Checking \`npx\` installed..."
 if ! which npx >/dev/null;
 then
    echo "\n❌ npx could not be found"
-   echo "  Consider installing npx to generate documentation.\n"
+   echo "  Consider installing npx.\n"
    echo "＞ \`npm install -g npx\`\n\n"
    exit 1
 fi
+echo "✅ \`npx\` installed"
 
+echo "❔ Checking \`awk\` installed..."
+if ! which awk >/dev/null;
+then
+   echo "\n❌ awk could not be found"
+   echo "  Consider installing awk."
+   exit 1
+fi
+echo "✅ \`perl\` installed"
+
+echo "❔ Checking \`perl\` installed..."
+if ! which perl >/dev/null;
+then
+   echo "\n❌ perl could not be found"
+   echo "  Consider installing perl."
+   exit 1
+fi
+echo "✅ \`perl\` installed"
+'''
+
+[tasks.docs-generate]
+dependencies = ["check-prerequisites", "docs-clean", "schema"]
+description = "Generate documentation"
+script = '''
 echo "🧹 Cleaning old documentation..."
 rm -rf $SCHEMA_FOLDER
 rm -rf $DOCS_FOLDER
@@ -110,17 +135,51 @@ mkdir -p $SCHEMA_FOLDER
 find contracts/*/schema -type f -maxdepth 1 -name '*.json' \
     -exec sh -c 'cp "$@" "$0"' $SCHEMA_FOLDER/ {} +
 
-
 mkdir -p $DOCS_FOLDER
 
 for SCHEMA in $(ls $SCHEMA_FOLDER); do
-    echo "Rendering $SCHEMA..."
-    awk "{sub(\"#/definitions\",\"./${SCHEMA}/#/definitions\")} {print}"  ${SCHEMA_FOLDER}/${SCHEMA} > ${SCHEMA_FOLDER}/${SCHEMA}.tmp
-    mv ${SCHEMA_FOLDER}/${SCHEMA}.tmp ${SCHEMA_FOLDER}/${SCHEMA}
+    from="$SCHEMA"
+    to="${SCHEMA%.json}.md"
+    echo "✍️ Rendering ${SCHEMA_FOLDER}/$from to $to"
 
-    npx --yes @fadroma/schema@1.1.0 ${SCHEMA_FOLDER}/${SCHEMA} > "${SCHEMA%.json}.md"
+    awk "{sub(\"#/definitions\",\"./${from}/#/definitions\")} {print}" ${SCHEMA_FOLDER}/$from > ${SCHEMA_FOLDER}/$from.tmp
+    mv ${SCHEMA_FOLDER}/${from}.tmp ${SCHEMA_FOLDER}/${from}
 
-    mv "${SCHEMA%.json}.md" "docs/${SCHEMA%.json}.md"
+    npx --yes @fadroma/schema@1.1.0 ${SCHEMA_FOLDER}/${from} > "docs/${to}.tmp"
+
+    perl << 'EOF' - "docs/${to}.tmp" > "docs/${to}"
+    use strict;
+    use warnings;
+
+    my $file = shift @ARGV;
+    local $/ = undef;
+
+    open my $fh, '<', $file or die "☠️ Could not open file: $!";
+    my $content = <$fh>;
+    close $fh;
+
+    my $in_code_block = 0;
+    my $in_inline_code = 0;
+    my $escaped_content = '';
+
+    foreach my $char (split //, $content) {
+      if ($char eq '`') {
+          $in_inline_code = !$in_inline_code unless $in_code_block;
+      } elsif ($char eq "\n") {
+          $in_code_block = 0 if ($in_code_block && $content =~ m/^\`\`\`/);
+      } elsif (!$in_code_block && !$in_inline_code && $char =~ /[{]/) {
+          $char = "\\{";
+      } elsif (!$in_code_block && !$in_inline_code && $char =~ /[}]/) {
+          $char = "\\}";
+      }
+      $escaped_content .= $char;
+      $in_code_block = 1 if ($char eq "\n" && $content =~ m/^\`\`\`/);
+    }
+
+    print $escaped_content;
+EOF
+
+    rm "docs/${to}.tmp"
 done
 
 rm -rf $SCHEMA_FOLDER

--- a/docs/okp4-cognitarium.md
+++ b/docs/okp4-cognitarium.md
@@ -10,16 +10,16 @@ The `okp4-cognitarium` smart contract enables the storage of [RDF graphs triples
 
 Instantiate message
 
-|parameter|description|
-|----------|-----------|
-|`limits`|**[StoreLimitsInput](#storelimitsinput)**. Limitations regarding store usage.|
-|`limits.max_byte_size`|**[Uint128](#uint128)**. The maximum number of bytes the store can contain. The size of a triple is counted as the sum of the size of its subject, predicate and object, including the size of data types and language tags if any. Default to [Uint128::MAX] if not set, which can be considered as no limit.<br />**Default:** `"340282366920938463463374607431768211455"`|
-|`limits.max_insert_data_byte_size`|**[Uint128](#uint128)**. The maximum number of bytes an insert data query can contain. Default to [Uint128::MAX] if not set, which can be considered as no limit.<br />**Default:** `"340282366920938463463374607431768211455"`|
-|`limits.max_insert_data_triple_count`|**[Uint128](#uint128)**. The maximum number of triples an insert data query can contain (after parsing). Default to [Uint128::MAX] if not set, which can be considered as no limit.<br />**Default:** `"340282366920938463463374607431768211455"`|
-|`limits.max_query_limit`|**integer**. The maximum limit of a query, i.e. the maximum number of triples returned by a select query. Default to 30 if not set.<br />**Default:** `30`|
-|`limits.max_query_variable_count`|**integer**. The maximum number of variables a query can select. Default to 30 if not set.<br />**Default:** `30`|
-|`limits.max_triple_byte_size`|**[Uint128](#uint128)**. The maximum number of bytes the store can contain for a single triple. The size of a triple is counted as the sum of the size of its subject, predicate and object, including the size of data types and language tags if any. The limit is used to prevent storing very large triples, especially literals. Default to [Uint128::MAX] if not set, which can be considered as no limit.<br />**Default:** `"340282366920938463463374607431768211455"`|
-|`limits.max_triple_count`|**[Uint128](#uint128)**. The maximum number of triples the store can contain. Default to [Uint128::MAX] if not set, which can be considered as no limit.<br />**Default:** `"340282366920938463463374607431768211455"`|
+| parameter                             | description                                                                                                                                                                                                                                                                                                                                                                                                                                                                    |
+| ------------------------------------- | ------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------ |
+| `limits`                              | **[StoreLimitsInput](#storelimitsinput)**. Limitations regarding store usage.                                                                                                                                                                                                                                                                                                                                                                                                  |
+| `limits.max_byte_size`                | **[Uint128](#uint128)**. The maximum number of bytes the store can contain. The size of a triple is counted as the sum of the size of its subject, predicate and object, including the size of data types and language tags if any. Default to [Uint128::MAX] if not set, which can be considered as no limit.<br />**Default:** `"340282366920938463463374607431768211455"`                                                                                                   |
+| `limits.max_insert_data_byte_size`    | **[Uint128](#uint128)**. The maximum number of bytes an insert data query can contain. Default to [Uint128::MAX] if not set, which can be considered as no limit.<br />**Default:** `"340282366920938463463374607431768211455"`                                                                                                                                                                                                                                                |
+| `limits.max_insert_data_triple_count` | **[Uint128](#uint128)**. The maximum number of triples an insert data query can contain (after parsing). Default to [Uint128::MAX] if not set, which can be considered as no limit.<br />**Default:** `"340282366920938463463374607431768211455"`                                                                                                                                                                                                                              |
+| `limits.max_query_limit`              | **integer**. The maximum limit of a query, i.e. the maximum number of triples returned by a select query. Default to 30 if not set.<br />**Default:** `30`                                                                                                                                                                                                                                                                                                                     |
+| `limits.max_query_variable_count`     | **integer**. The maximum number of variables a query can select. Default to 30 if not set.<br />**Default:** `30`                                                                                                                                                                                                                                                                                                                                                              |
+| `limits.max_triple_byte_size`         | **[Uint128](#uint128)**. The maximum number of bytes the store can contain for a single triple. The size of a triple is counted as the sum of the size of its subject, predicate and object, including the size of data types and language tags if any. The limit is used to prevent storing very large triples, especially literals. Default to [Uint128::MAX] if not set, which can be considered as no limit.<br />**Default:** `"340282366920938463463374607431768211455"` |
+| `limits.max_triple_count`             | **[Uint128](#uint128)**. The maximum number of triples the store can contain. Default to [Uint128::MAX] if not set, which can be considered as no limit.<br />**Default:** `"340282366920938463463374607431768211455"`                                                                                                                                                                                                                                                         |
 
 ## ExecuteMsg
 
@@ -31,26 +31,26 @@ Insert the data as RDF triples in the store. For already existing triples it act
 
 Only the smart contract owner (i.e. the address who instantiated it) is authorized to perform this action.
 
-|parameter|description|
-|----------|-----------|
-|`insert_data`|*(Required.) * **object**. |
-|`insert_data.data`|*(Required.) * **[Binary](#binary)**. The data to insert. The data must be serialized in the format specified by the `format` field. And the data are subject to the limitations defined by the `limits` specified at contract instantiation.|
-|`insert_data.format`|**[DataFormat](#dataformat)\|null**. The data format in which the triples are serialized. If not provided, the default format is [Turtle](https://www.w3.org/TR/turtle/) format.|
+| parameter            | description                                                                                                                                                                                                                                   |
+| -------------------- | --------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
+| `insert_data`        | _(Required.) _ **object**.                                                                                                                                                                                                                    |
+| `insert_data.data`   | _(Required.) _ **[Binary](#binary)**. The data to insert. The data must be serialized in the format specified by the `format` field. And the data are subject to the limitations defined by the `limits` specified at contract instantiation. |
+| `insert_data.format` | **[DataFormat](#dataformat)\|null**. The data format in which the triples are serialized. If not provided, the default format is [Turtle](https://www.w3.org/TR/turtle/) format.                                                              |
 
 ### ExecuteMsg::DeleteData
 
 Delete the data (RDF triples) from the store matching the patterns defined by the provided query. For non-existing triples it acts as no-op.
 
-Example: ```json { "prefixes": [ { "prefix": "foaf", "namespace": "http://xmlns.com/foaf/0.1/" } ], "delete": [ { "subject": { "variable": "s" }, "predicate": { "variable": "p" }, "object": { "variable": "o" } } ], "where": [ { "simple": { "triplePattern": { "subject": { "variable": "s" }, "predicate": { "node": { "namedNode": {"prefixed": "foaf:givenName"} } }, "object": { "literal": { "simple": "Myrddin" } } } } }, { "simple": { "triplePattern": { "subject": { "variable": "s" }, "predicate": { "variable": "p" }, "object": { "variable": "o" } } } } ] ```
+Example: `json { "prefixes": [ { "prefix": "foaf", "namespace": "http://xmlns.com/foaf/0.1/" } ], "delete": [ { "subject": { "variable": "s" }, "predicate": { "variable": "p" }, "object": { "variable": "o" } } ], "where": [ { "simple": { "triplePattern": { "subject": { "variable": "s" }, "predicate": { "node": { "namedNode": {"prefixed": "foaf:givenName"} } }, "object": { "literal": { "simple": "Myrddin" } } } } }, { "simple": { "triplePattern": { "subject": { "variable": "s" }, "predicate": { "variable": "p" }, "object": { "variable": "o" } } } } ] `
 
 Only the smart contract owner (i.e. the address who instantiated it) is authorized to perform this action.
 
-|parameter|description|
-|----------|-----------|
-|`delete_data`|*(Required.) * **object**. |
-|`delete_data.delete`|*(Required.) * **Array&lt;[TriplePattern](#triplepattern)&gt;**. Specifies the specific triple patterns to delete. If nothing is provided, the patterns from the `where` clause are used for deletion.|
-|`delete_data.prefixes`|*(Required.) * **Array&lt;[Prefix](#prefix)&gt;**. The prefixes used in the operation.|
-|`delete_data.where`|*(Required.) * **Array&lt;[WhereCondition](#wherecondition)&gt;**. Defines the patterns that data (RDF triples) should match in order for it to be considered for deletion.|
+| parameter              | description                                                                                                                                                                                            |
+| ---------------------- | ------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------ |
+| `delete_data`          | _(Required.) _ **object**.                                                                                                                                                                             |
+| `delete_data.delete`   | _(Required.) _ **Array&lt;[TriplePattern](#triplepattern)&gt;**. Specifies the specific triple patterns to delete. If nothing is provided, the patterns from the `where` clause are used for deletion. |
+| `delete_data.prefixes` | _(Required.) _ **Array&lt;[Prefix](#prefix)&gt;**. The prefixes used in the operation.                                                                                                                 |
+| `delete_data.where`    | _(Required.) _ **Array&lt;[WhereCondition](#wherecondition)&gt;**. Defines the patterns that data (RDF triples) should match in order for it to be considered for deletion.                            |
 
 ## QueryMsg
 
@@ -60,38 +60,38 @@ Query messages
 
 Returns information about the triple store.
 
-|literal|
-|-------|
-|`"store"`|
+| literal   |
+| --------- |
+| `"store"` |
 
 ### QueryMsg::Select
 
 Returns the resources matching the criteria defined by the provided query.
 
-|parameter|description|
-|----------|-----------|
-|`select`|*(Required.) * **object**. |
-|`select.query`|*(Required.) * **[SelectQuery](#selectquery)**. The query to execute.|
+| parameter      | description                                                           |
+| -------------- | --------------------------------------------------------------------- |
+| `select`       | _(Required.) _ **object**.                                            |
+| `select.query` | _(Required.) _ **[SelectQuery](#selectquery)**. The query to execute. |
 
 ### QueryMsg::Describe
 
 Returns a description of the resource identified by the provided IRI as a set of RDF triples serialized in the provided format.
 
-|parameter|description|
-|----------|-----------|
-|`describe`|*(Required.) * **object**. |
-|`describe.format`|**[DataFormat](#dataformat)\|null**. The format in which the triples are serialized. If not provided, the default format is [Turtle](https://www.w3.org/TR/turtle/) format.|
-|`describe.query`|*(Required.) * **[DescribeQuery](#describequery)**. The query to execute.|
+| parameter         | description                                                                                                                                                                 |
+| ----------------- | --------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
+| `describe`        | _(Required.) _ **object**.                                                                                                                                                  |
+| `describe.format` | **[DataFormat](#dataformat)\|null**. The format in which the triples are serialized. If not provided, the default format is [Turtle](https://www.w3.org/TR/turtle/) format. |
+| `describe.query`  | _(Required.) _ **[DescribeQuery](#describequery)**. The query to execute.                                                                                                   |
 
 ### QueryMsg::Construct
 
 Returns the resources matching the criteria defined by the provided query as a set of RDF triples serialized in the provided format.
 
-|parameter|description|
-|----------|-----------|
-|`construct`|*(Required.) * **object**. |
-|`construct.format`|**[DataFormat](#dataformat)\|null**. The format in which the triples are serialized. If not provided, the default format is [Turtle](https://www.w3.org/TR/turtle/) format.|
-|`construct.query`|*(Required.) * **[ConstructQuery](#constructquery)**. The query to execute.|
+| parameter          | description                                                                                                                                                                 |
+| ------------------ | --------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
+| `construct`        | _(Required.) _ **object**.                                                                                                                                                  |
+| `construct.format` | **[DataFormat](#dataformat)\|null**. The format in which the triples are serialized. If not provided, the default format is [Turtle](https://www.w3.org/TR/turtle/) format. |
+| `construct.query`  | _(Required.) _ **[ConstructQuery](#constructquery)**. The query to execute.                                                                                                 |
 
 ## Responses
 
@@ -99,50 +99,50 @@ Returns the resources matching the criteria defined by the provided query as a s
 
 Represents the response of a [QueryMsg::Construct] query.
 
-|property|description|
-|----------|-----------|
-|`data`|*(Required.) * **[Binary](#binary)**. The data serialized in the specified format.|
-|`format`|*(Required.) * **[DataFormat](#dataformat)**. The format of the data.|
+| property | description                                                                        |
+| -------- | ---------------------------------------------------------------------------------- |
+| `data`   | _(Required.) _ **[Binary](#binary)**. The data serialized in the specified format. |
+| `format` | _(Required.) _ **[DataFormat](#dataformat)**. The format of the data.              |
 
 ### describe
 
 Represents the response of a [QueryMsg::Describe] query.
 
-|property|description|
-|----------|-----------|
-|`data`|*(Required.) * **[Binary](#binary)**. The data serialized in the specified format.|
-|`format`|*(Required.) * **[DataFormat](#dataformat)**. The format of the data.|
+| property | description                                                                        |
+| -------- | ---------------------------------------------------------------------------------- |
+| `data`   | _(Required.) _ **[Binary](#binary)**. The data serialized in the specified format. |
+| `format` | _(Required.) _ **[DataFormat](#dataformat)**. The format of the data.              |
 
 ### select
 
 Represents the response of a [QueryMsg::Select] query.
 
-|property|description|
-|----------|-----------|
-|`head`|*(Required.) * **[Head](#head)**. The head of the response, i.e. the set of variables mentioned in the results.|
-|`head.vars`|**Array&lt;string&gt;**. The variables selected in the query.|
-|`results`|*(Required.) * **[Results](#results)**. The results of the select query.|
-|`results.bindings`|**Array&lt;object&gt;**. The bindings of the results.|
+| property           | description                                                                                                     |
+| ------------------ | --------------------------------------------------------------------------------------------------------------- |
+| `head`             | _(Required.) _ **[Head](#head)**. The head of the response, i.e. the set of variables mentioned in the results. |
+| `head.vars`        | **Array&lt;string&gt;**. The variables selected in the query.                                                   |
+| `results`          | _(Required.) _ **[Results](#results)**. The results of the select query.                                        |
+| `results.bindings` | **Array&lt;object&gt;**. The bindings of the results.                                                           |
 
 ### store
 
 Contains information related to triple store.
 
-|property|description|
-|----------|-----------|
-|`limits`|*(Required.) * **[StoreLimits](#storelimits)**. The store limits.|
-|`limits.max_byte_size`|**[Uint128](#uint128)**. The maximum number of bytes the store can contain. The size of a triple is counted as the sum of the size of its subject, predicate and object, including the size of data types and language tags if any.|
-|`limits.max_insert_data_byte_size`|**[Uint128](#uint128)**. The maximum number of bytes an insert data query can contain.|
-|`limits.max_insert_data_triple_count`|**[Uint128](#uint128)**. The maximum number of triples an insert data query can contain (after parsing).|
-|`limits.max_query_limit`|**integer**. The maximum limit of a query, i.e. the maximum number of triples returned by a select query.|
-|`limits.max_query_variable_count`|**integer**. The maximum number of variables a query can select.|
-|`limits.max_triple_byte_size`|**[Uint128](#uint128)**. The maximum number of bytes the store can contain for a single triple. The size of a triple is counted as the sum of the size of its subject, predicate and object, including the size of data types and language tags if any. The limit is used to prevent storing very large triples, especially literals.|
-|`limits.max_triple_count`|**[Uint128](#uint128)**. The maximum number of triples the store can contain.|
-|`owner`|*(Required.) * **string**. The store owner.|
-|`stat`|*(Required.) * **[StoreStat](#storestat)**. The store current usage.|
-|`stat.byte_size`|**[Uint128](#uint128)**. The total triple size in the store, in bytes.|
-|`stat.namespace_count`|**[Uint128](#uint128)**. The total number of IRI namespace present in the store.|
-|`stat.triple_count`|**[Uint128](#uint128)**. The total number of triple present in the store.|
+| property                              | description                                                                                                                                                                                                                                                                                                                           |
+| ------------------------------------- | ------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
+| `limits`                              | _(Required.) _ **[StoreLimits](#storelimits)**. The store limits.                                                                                                                                                                                                                                                                     |
+| `limits.max_byte_size`                | **[Uint128](#uint128)**. The maximum number of bytes the store can contain. The size of a triple is counted as the sum of the size of its subject, predicate and object, including the size of data types and language tags if any.                                                                                                   |
+| `limits.max_insert_data_byte_size`    | **[Uint128](#uint128)**. The maximum number of bytes an insert data query can contain.                                                                                                                                                                                                                                                |
+| `limits.max_insert_data_triple_count` | **[Uint128](#uint128)**. The maximum number of triples an insert data query can contain (after parsing).                                                                                                                                                                                                                              |
+| `limits.max_query_limit`              | **integer**. The maximum limit of a query, i.e. the maximum number of triples returned by a select query.                                                                                                                                                                                                                             |
+| `limits.max_query_variable_count`     | **integer**. The maximum number of variables a query can select.                                                                                                                                                                                                                                                                      |
+| `limits.max_triple_byte_size`         | **[Uint128](#uint128)**. The maximum number of bytes the store can contain for a single triple. The size of a triple is counted as the sum of the size of its subject, predicate and object, including the size of data types and language tags if any. The limit is used to prevent storing very large triples, especially literals. |
+| `limits.max_triple_count`             | **[Uint128](#uint128)**. The maximum number of triples the store can contain.                                                                                                                                                                                                                                                         |
+| `owner`                               | _(Required.) _ **string**. The store owner.                                                                                                                                                                                                                                                                                           |
+| `stat`                                | _(Required.) _ **[StoreStat](#storestat)**. The store current usage.                                                                                                                                                                                                                                                                  |
+| `stat.byte_size`                      | **[Uint128](#uint128)**. The total triple size in the store, in bytes.                                                                                                                                                                                                                                                                |
+| `stat.namespace_count`                | **[Uint128](#uint128)**. The total number of IRI namespace present in the store.                                                                                                                                                                                                                                                      |
+| `stat.triple_count`                   | **[Uint128](#uint128)**. The total number of triple present in the store.                                                                                                                                                                                                                                                             |
 
 ## Definitions
 
@@ -150,332 +150,330 @@ Contains information related to triple store.
 
 A string containing Base64-encoded data.
 
-|type|
-|----|
-|**string**.|
+| type        |
+| ----------- |
+| **string**. |
 
 ### BlankNode
 
 An RDF [blank node](https://www.w3.org/TR/rdf11-concepts/#dfn-blank-node).
 
-|property|description|
-|----------|-----------|
-|`blank_node`|*(Required.) * **string**. |
+| property     | description                |
+| ------------ | -------------------------- |
+| `blank_node` | _(Required.) _ **string**. |
 
 ### ConstructQuery
 
 Represents a CONSTRUCT query over the triple store, allowing to retrieve a set of triples serialized in a specific format.
 
-|property|description|
-|----------|-----------|
-|`construct`|*(Required.) * **Array&lt;[TriplePattern](#triplepattern)&gt;**. The triples to construct. If nothing is provided, the patterns from the `where` clause are used for construction.|
-|`prefixes`|*(Required.) * **Array&lt;[Prefix](#prefix)&gt;**. The prefixes used in the query.|
-|`where`|*(Required.) * **Array&lt;[WhereCondition](#wherecondition)&gt;**. The WHERE clause. This clause is used to specify the triples to construct using variable bindings.|
+| property    | description                                                                                                                                                                        |
+| ----------- | ---------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
+| `construct` | _(Required.) _ **Array&lt;[TriplePattern](#triplepattern)&gt;**. The triples to construct. If nothing is provided, the patterns from the `where` clause are used for construction. |
+| `prefixes`  | _(Required.) _ **Array&lt;[Prefix](#prefix)&gt;**. The prefixes used in the query.                                                                                                 |
+| `where`     | _(Required.) _ **Array&lt;[WhereCondition](#wherecondition)&gt;**. The WHERE clause. This clause is used to specify the triples to construct using variable bindings.              |
 
 ### DataFormat
 
 Represents the format in which the data are serialized, for example when returned by a query or when inserted in the store.
 
-|variant|description|
-|-------|-----------|
-|[RDF XML](#rdf-xml)|**string**: `rdf_xml`. Output in [RDF/XML](https://www.w3.org/TR/rdf-syntax-grammar/) format.|
-|[Turtle](#turtle)|**string**: `turtle`. Output in [Turtle](https://www.w3.org/TR/turtle/) format.|
-|[N-Triples](#n-triples)|**string**: `n_triples`. Output in [N-Triples](https://www.w3.org/TR/n-triples/) format.|
-|[N-Quads](#n-quads)|**string**: `n_quads`. Output in [N-Quads](https://www.w3.org/TR/n-quads/) format.|
+| variant                 | description                                                                                   |
+| ----------------------- | --------------------------------------------------------------------------------------------- |
+| [RDF XML](#rdf-xml)     | **string**: `rdf_xml`. Output in [RDF/XML](https://www.w3.org/TR/rdf-syntax-grammar/) format. |
+| [Turtle](#turtle)       | **string**: `turtle`. Output in [Turtle](https://www.w3.org/TR/turtle/) format.               |
+| [N-Triples](#n-triples) | **string**: `n_triples`. Output in [N-Triples](https://www.w3.org/TR/n-triples/) format.      |
+| [N-Quads](#n-quads)     | **string**: `n_quads`. Output in [N-Quads](https://www.w3.org/TR/n-quads/) format.            |
 
 ### DescribeQuery
 
 Represents a DESCRIBE query over the triple store, allowing to retrieve a description of a resource as a set of triples serialized in a specific format.
 
-|property|description|
-|----------|-----------|
-|`prefixes`|*(Required.) * **Array&lt;[Prefix](#prefix)&gt;**. The prefixes used in the query.|
-|`resource`|*(Required.) * **[VarOrNamedNode](#varornamednode)**. The resource to describe given as a variable or a node.|
-|`where`|*(Required.) * **Array&lt;[WhereCondition](#wherecondition)&gt;**. The WHERE clause. This clause is used to specify the resource identifier to describe using variable bindings.|
+| property   | description                                                                                                                                                                      |
+| ---------- | -------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
+| `prefixes` | _(Required.) _ **Array&lt;[Prefix](#prefix)&gt;**. The prefixes used in the query.                                                                                               |
+| `resource` | _(Required.) _ **[VarOrNamedNode](#varornamednode)**. The resource to describe given as a variable or a node.                                                                    |
+| `where`    | _(Required.) _ **Array&lt;[WhereCondition](#wherecondition)&gt;**. The WHERE clause. This clause is used to specify the resource identifier to describe using variable bindings. |
 
 ### Full
 
 A full IRI.
 
-|property|description|
-|----------|-----------|
-|`full`|*(Required.) * **string**. |
+| property | description                |
+| -------- | -------------------------- |
+| `full`   | _(Required.) _ **string**. |
 
 ### Head
 
 Represents the head of a [SelectResponse].
 
-|property|description|
-|----------|-----------|
-|`vars`|*(Required.) * **Array&lt;string&gt;**. The variables selected in the query.|
+| property | description                                                                  |
+| -------- | ---------------------------------------------------------------------------- |
+| `vars`   | _(Required.) _ **Array&lt;string&gt;**. The variables selected in the query. |
 
 ### IRI
 
 Represents an IRI.
 
-|variant|description|
-|-------|-----------|
-|[Prefixed](#prefixed)|**object**. An IRI prefixed with a prefix. The prefixed IRI is expanded to a full IRI using the prefix definition specified in the query. For example, the prefixed IRI `rdf:type` is expanded to `http://www.w3.org/1999/02/22-rdf-syntax-ns#type`.|
-|[Full](#full)|**object**. A full IRI.|
+| variant               | description                                                                                                                                                                                                                                          |
+| --------------------- | ---------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
+| [Prefixed](#prefixed) | **object**. An IRI prefixed with a prefix. The prefixed IRI is expanded to a full IRI using the prefix definition specified in the query. For example, the prefixed IRI `rdf:type` is expanded to `http://www.w3.org/1999/02/22-rdf-syntax-ns#type`. |
+| [Full](#full)         | **object**. A full IRI.                                                                                                                                                                                                                              |
 
 ### LanguageTaggedString
 
 A [language-tagged string](https://www.w3.org/TR/rdf11-concepts/#dfn-language-tagged-string)
 
-|property|description|
-|----------|-----------|
-|`language_tagged_string`|*(Required.) * **object**. |
-|`language_tagged_string.language`|*(Required.) * **string**. The [language tag](https://www.w3.org/TR/rdf11-concepts/#dfn-language-tag).|
-|`language_tagged_string.value`|*(Required.) * **string**. The [lexical form](https://www.w3.org/TR/rdf11-concepts/#dfn-lexical-form).|
+| property                          | description                                                                                            |
+| --------------------------------- | ------------------------------------------------------------------------------------------------------ |
+| `language_tagged_string`          | _(Required.) _ **object**.                                                                             |
+| `language_tagged_string.language` | _(Required.) _ **string**. The [language tag](https://www.w3.org/TR/rdf11-concepts/#dfn-language-tag). |
+| `language_tagged_string.value`    | _(Required.) _ **string**. The [lexical form](https://www.w3.org/TR/rdf11-concepts/#dfn-lexical-form). |
 
 ### Literal
 
 An RDF [literal](https://www.w3.org/TR/rdf11-concepts/#dfn-literal).
 
-|variant|description|
-|-------|-----------|
-|[Simple](#simple)|**object**. A [simple literal](https://www.w3.org/TR/rdf11-concepts/#dfn-simple-literal) without datatype or language form.|
-|[LanguageTaggedString](#languagetaggedstring)|**object**. A [language-tagged string](https://www.w3.org/TR/rdf11-concepts/#dfn-language-tagged-string)|
-|[TypedValue](#typedvalue)|**object**. A value with a datatype.|
+| variant                                       | description                                                                                                                 |
+| --------------------------------------------- | --------------------------------------------------------------------------------------------------------------------------- |
+| [Simple](#simple)                             | **object**. A [simple literal](https://www.w3.org/TR/rdf11-concepts/#dfn-simple-literal) without datatype or language form. |
+| [LanguageTaggedString](#languagetaggedstring) | **object**. A [language-tagged string](https://www.w3.org/TR/rdf11-concepts/#dfn-language-tagged-string)                    |
+| [TypedValue](#typedvalue)                     | **object**. A value with a datatype.                                                                                        |
 
 ### N-Quads
 
 Output in [N-Quads](https://www.w3.org/TR/n-quads/) format.
 
-|literal|
-|-------|
-|`"n_quads"`|
+| literal     |
+| ----------- |
+| `"n_quads"` |
 
 ### N-Triples
 
 Output in [N-Triples](https://www.w3.org/TR/n-triples/) format.
 
-|literal|
-|-------|
-|`"n_triples"`|
+| literal       |
+| ------------- |
+| `"n_triples"` |
 
 ### NamedNode
 
 An RDF [IRI](https://www.w3.org/TR/rdf11-concepts/#dfn-iri).
 
-|property|description|
-|----------|-----------|
-|`named_node`|*(Required.) * **[Prefixed](#prefixed)\|[Full](#full)**. |
+| property     | description                                              |
+| ------------ | -------------------------------------------------------- |
+| `named_node` | _(Required.) _ **[Prefixed](#prefixed)\|[Full](#full)**. |
 
 ### Node
 
 Represents either an IRI (named node) or a blank node.
 
-|variant|description|
-|-------|-----------|
-|[NamedNode](#namednode)|**object**. An RDF [IRI](https://www.w3.org/TR/rdf11-concepts/#dfn-iri).|
-|[BlankNode](#blanknode)|**object**. An RDF [blank node](https://www.w3.org/TR/rdf11-concepts/#dfn-blank-node).|
+| variant                 | description                                                                            |
+| ----------------------- | -------------------------------------------------------------------------------------- |
+| [NamedNode](#namednode) | **object**. An RDF [IRI](https://www.w3.org/TR/rdf11-concepts/#dfn-iri).               |
+| [BlankNode](#blanknode) | **object**. An RDF [blank node](https://www.w3.org/TR/rdf11-concepts/#dfn-blank-node). |
 
 ### Prefix
 
 Represents a prefix, i.e. a shortcut for a namespace used in a query.
 
-|property|description|
-|----------|-----------|
-|`namespace`|*(Required.) * **string**. The namespace associated with the prefix.|
-|`prefix`|*(Required.) * **string**. The prefix.|
+| property    | description                                                          |
+| ----------- | -------------------------------------------------------------------- |
+| `namespace` | _(Required.) _ **string**. The namespace associated with the prefix. |
+| `prefix`    | _(Required.) _ **string**. The prefix.                               |
 
 ### Prefixed
 
 An IRI prefixed with a prefix. The prefixed IRI is expanded to a full IRI using the prefix definition specified in the query. For example, the prefixed IRI `rdf:type` is expanded to `http://www.w3.org/1999/02/22-rdf-syntax-ns#type`.
 
-|property|description|
-|----------|-----------|
-|`prefixed`|*(Required.) * **string**. |
+| property   | description                |
+| ---------- | -------------------------- |
+| `prefixed` | _(Required.) _ **string**. |
 
 ### RDF XML
 
 Output in [RDF/XML](https://www.w3.org/TR/rdf-syntax-grammar/) format.
 
-|literal|
-|-------|
-|`"rdf_xml"`|
+| literal     |
+| ----------- |
+| `"rdf_xml"` |
 
 ### Results
 
 Represents the results of a [SelectResponse].
 
-|property|description|
-|----------|-----------|
-|`bindings`|*(Required.) * **Array&lt;object&gt;**. The bindings of the results.|
+| property   | description                                                          |
+| ---------- | -------------------------------------------------------------------- |
+| `bindings` | _(Required.) _ **Array&lt;object&gt;**. The bindings of the results. |
 
 ### SelectItem
 
 Represents an item to select in a [SelectQuery].
 
-|variant|description|
-|-------|-----------|
-|[Variable](#variable)|**object**. Represents a variable.|
+| variant               | description                        |
+| --------------------- | ---------------------------------- |
+| [Variable](#variable) | **object**. Represents a variable. |
 
 ### SelectQuery
 
 Represents a SELECT query over the triple store, allowing to select variables to return and to filter the results.
 
-|property|description|
-|----------|-----------|
-|`limit`|**integer\|null**. The maximum number of results to return. If `None`, there is no limit. Note: the value of the limit cannot exceed the maximum query limit defined in the store limitations.|
-|`prefixes`|*(Required.) * **Array&lt;[Prefix](#prefix)&gt;**. The prefixes used in the query.|
-|`select`|*(Required.) * **Array&lt;[SelectItem](#selectitem)&gt;**. The items to select. Note: the number of items to select cannot exceed the maximum query variable count defined in the store limitations.|
-|`where`|*(Required.) * **Array&lt;[WhereCondition](#wherecondition)&gt;**. The WHERE clause. If `None`, there is no WHERE clause, i.e. all triples are returned without filtering.|
+| property   | description                                                                                                                                                                                          |
+| ---------- | ---------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
+| `limit`    | **integer\|null**. The maximum number of results to return. If `None`, there is no limit. Note: the value of the limit cannot exceed the maximum query limit defined in the store limitations.       |
+| `prefixes` | _(Required.) _ **Array&lt;[Prefix](#prefix)&gt;**. The prefixes used in the query.                                                                                                                   |
+| `select`   | _(Required.) _ **Array&lt;[SelectItem](#selectitem)&gt;**. The items to select. Note: the number of items to select cannot exceed the maximum query variable count defined in the store limitations. |
+| `where`    | _(Required.) _ **Array&lt;[WhereCondition](#wherecondition)&gt;**. The WHERE clause. If `None`, there is no WHERE clause, i.e. all triples are returned without filtering.                           |
 
 ### Simple
 
 A [simple literal](https://www.w3.org/TR/rdf11-concepts/#dfn-simple-literal) without datatype or language form.
 
-|property|description|
-|----------|-----------|
-|`simple`|*(Required.) * **string**. |
+| property | description                |
+| -------- | -------------------------- |
+| `simple` | _(Required.) _ **string**. |
 
 ### SimpleWhereCondition
 
 Represents a simple condition in a [WhereCondition].
 
-|variant|description|
-|-------|-----------|
-|[TriplePattern](#triplepattern)|**object**. Represents a triple pattern, i.e. a condition on a triple based on its subject, predicate and object.|
+| variant                         | description                                                                                                       |
+| ------------------------------- | ----------------------------------------------------------------------------------------------------------------- |
+| [TriplePattern](#triplepattern) | **object**. Represents a triple pattern, i.e. a condition on a triple based on its subject, predicate and object. |
 
 ### StoreLimits
 
 Contains limitations regarding store usages.
 
-|property|description|
-|----------|-----------|
-|`max_byte_size`|*(Required.) * **[Uint128](#uint128)**. The maximum number of bytes the store can contain. The size of a triple is counted as the sum of the size of its subject, predicate and object, including the size of data types and language tags if any.|
-|`max_insert_data_byte_size`|*(Required.) * **[Uint128](#uint128)**. The maximum number of bytes an insert data query can contain.|
-|`max_insert_data_triple_count`|*(Required.) * **[Uint128](#uint128)**. The maximum number of triples an insert data query can contain (after parsing).|
-|`max_query_limit`|*(Required.) * **integer**. The maximum limit of a query, i.e. the maximum number of triples returned by a select query.|
-|`max_query_variable_count`|*(Required.) * **integer**. The maximum number of variables a query can select.|
-|`max_triple_byte_size`|*(Required.) * **[Uint128](#uint128)**. The maximum number of bytes the store can contain for a single triple. The size of a triple is counted as the sum of the size of its subject, predicate and object, including the size of data types and language tags if any. The limit is used to prevent storing very large triples, especially literals.|
-|`max_triple_count`|*(Required.) * **[Uint128](#uint128)**. The maximum number of triples the store can contain.|
+| property                       | description                                                                                                                                                                                                                                                                                                                                          |
+| ------------------------------ | ---------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
+| `max_byte_size`                | _(Required.) _ **[Uint128](#uint128)**. The maximum number of bytes the store can contain. The size of a triple is counted as the sum of the size of its subject, predicate and object, including the size of data types and language tags if any.                                                                                                   |
+| `max_insert_data_byte_size`    | _(Required.) _ **[Uint128](#uint128)**. The maximum number of bytes an insert data query can contain.                                                                                                                                                                                                                                                |
+| `max_insert_data_triple_count` | _(Required.) _ **[Uint128](#uint128)**. The maximum number of triples an insert data query can contain (after parsing).                                                                                                                                                                                                                              |
+| `max_query_limit`              | _(Required.) _ **integer**. The maximum limit of a query, i.e. the maximum number of triples returned by a select query.                                                                                                                                                                                                                             |
+| `max_query_variable_count`     | _(Required.) _ **integer**. The maximum number of variables a query can select.                                                                                                                                                                                                                                                                      |
+| `max_triple_byte_size`         | _(Required.) _ **[Uint128](#uint128)**. The maximum number of bytes the store can contain for a single triple. The size of a triple is counted as the sum of the size of its subject, predicate and object, including the size of data types and language tags if any. The limit is used to prevent storing very large triples, especially literals. |
+| `max_triple_count`             | _(Required.) _ **[Uint128](#uint128)**. The maximum number of triples the store can contain.                                                                                                                                                                                                                                                         |
 
 ### StoreLimitsInput
 
 Contains requested limitations regarding store usages.
 
-|property|description|
-|----------|-----------|
-|`max_byte_size`|**[Uint128](#uint128)**. The maximum number of bytes the store can contain. The size of a triple is counted as the sum of the size of its subject, predicate and object, including the size of data types and language tags if any. Default to [Uint128::MAX] if not set, which can be considered as no limit.|
-|`max_insert_data_byte_size`|**[Uint128](#uint128)**. The maximum number of bytes an insert data query can contain. Default to [Uint128::MAX] if not set, which can be considered as no limit.|
-|`max_insert_data_triple_count`|**[Uint128](#uint128)**. The maximum number of triples an insert data query can contain (after parsing). Default to [Uint128::MAX] if not set, which can be considered as no limit.|
-|`max_query_limit`|**integer**. The maximum limit of a query, i.e. the maximum number of triples returned by a select query. Default to 30 if not set.|
-|`max_query_variable_count`|**integer**. The maximum number of variables a query can select. Default to 30 if not set.|
-|`max_triple_byte_size`|**[Uint128](#uint128)**. The maximum number of bytes the store can contain for a single triple. The size of a triple is counted as the sum of the size of its subject, predicate and object, including the size of data types and language tags if any. The limit is used to prevent storing very large triples, especially literals. Default to [Uint128::MAX] if not set, which can be considered as no limit.|
-|`max_triple_count`|**[Uint128](#uint128)**. The maximum number of triples the store can contain. Default to [Uint128::MAX] if not set, which can be considered as no limit.|
+| property                       | description                                                                                                                                                                                                                                                                                                                                                                                                      |
+| ------------------------------ | ---------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
+| `max_byte_size`                | **[Uint128](#uint128)**. The maximum number of bytes the store can contain. The size of a triple is counted as the sum of the size of its subject, predicate and object, including the size of data types and language tags if any. Default to [Uint128::MAX] if not set, which can be considered as no limit.                                                                                                   |
+| `max_insert_data_byte_size`    | **[Uint128](#uint128)**. The maximum number of bytes an insert data query can contain. Default to [Uint128::MAX] if not set, which can be considered as no limit.                                                                                                                                                                                                                                                |
+| `max_insert_data_triple_count` | **[Uint128](#uint128)**. The maximum number of triples an insert data query can contain (after parsing). Default to [Uint128::MAX] if not set, which can be considered as no limit.                                                                                                                                                                                                                              |
+| `max_query_limit`              | **integer**. The maximum limit of a query, i.e. the maximum number of triples returned by a select query. Default to 30 if not set.                                                                                                                                                                                                                                                                              |
+| `max_query_variable_count`     | **integer**. The maximum number of variables a query can select. Default to 30 if not set.                                                                                                                                                                                                                                                                                                                       |
+| `max_triple_byte_size`         | **[Uint128](#uint128)**. The maximum number of bytes the store can contain for a single triple. The size of a triple is counted as the sum of the size of its subject, predicate and object, including the size of data types and language tags if any. The limit is used to prevent storing very large triples, especially literals. Default to [Uint128::MAX] if not set, which can be considered as no limit. |
+| `max_triple_count`             | **[Uint128](#uint128)**. The maximum number of triples the store can contain. Default to [Uint128::MAX] if not set, which can be considered as no limit.                                                                                                                                                                                                                                                         |
 
 ### StoreStat
 
 Contains usage information about the triple store.
 
-|property|description|
-|----------|-----------|
-|`byte_size`|*(Required.) * **[Uint128](#uint128)**. The total triple size in the store, in bytes.|
-|`namespace_count`|*(Required.) * **[Uint128](#uint128)**. The total number of IRI namespace present in the store.|
-|`triple_count`|*(Required.) * **[Uint128](#uint128)**. The total number of triple present in the store.|
+| property          | description                                                                                     |
+| ----------------- | ----------------------------------------------------------------------------------------------- |
+| `byte_size`       | _(Required.) _ **[Uint128](#uint128)**. The total triple size in the store, in bytes.           |
+| `namespace_count` | _(Required.) _ **[Uint128](#uint128)**. The total number of IRI namespace present in the store. |
+| `triple_count`    | _(Required.) _ **[Uint128](#uint128)**. The total number of triple present in the store.        |
 
 ### TriplePattern
 
 Represents a triple pattern in a [SimpleWhereCondition].
 
-|property|description|
-|----------|-----------|
-|`object`|*(Required.) * **[VarOrNodeOrLiteral](#varornodeorliteral)**. The object of the triple pattern.|
-|`predicate`|*(Required.) * **[VarOrNode](#varornode)**. The predicate of the triple pattern.|
-|`subject`|*(Required.) * **[VarOrNode](#varornode)**. The subject of the triple pattern.|
+| property    | description                                                                                     |
+| ----------- | ----------------------------------------------------------------------------------------------- |
+| `object`    | _(Required.) _ **[VarOrNodeOrLiteral](#varornodeorliteral)**. The object of the triple pattern. |
+| `predicate` | _(Required.) _ **[VarOrNode](#varornode)**. The predicate of the triple pattern.                |
+| `subject`   | _(Required.) _ **[VarOrNode](#varornode)**. The subject of the triple pattern.                  |
 
 ### Turtle
 
 Output in [Turtle](https://www.w3.org/TR/turtle/) format.
 
-|literal|
-|-------|
-|`"turtle"`|
+| literal    |
+| ---------- |
+| `"turtle"` |
 
 ### TypedValue
 
 A value with a datatype.
 
-|property|description|
-|----------|-----------|
-|`typed_value`|*(Required.) * **object**. |
-|`typed_value.datatype`|*(Required.) * **[IRI](#iri)**. The [datatype IRI](https://www.w3.org/TR/rdf11-concepts/#dfn-datatype-iri).|
-|`typed_value.value`|*(Required.) * **string**. The [lexical form](https://www.w3.org/TR/rdf11-concepts/#dfn-lexical-form).|
+| property               | description                                                                                                 |
+| ---------------------- | ----------------------------------------------------------------------------------------------------------- |
+| `typed_value`          | _(Required.) _ **object**.                                                                                  |
+| `typed_value.datatype` | _(Required.) _ **[IRI](#iri)**. The [datatype IRI](https://www.w3.org/TR/rdf11-concepts/#dfn-datatype-iri). |
+| `typed_value.value`    | _(Required.) _ **string**. The [lexical form](https://www.w3.org/TR/rdf11-concepts/#dfn-lexical-form).      |
 
 ### URI
 
 Represents an IRI.
 
-|property|description|
-|----------|-----------|
-|`type`|*(Required.) * **string**. |
-|`value`|*(Required.) * **[IRI](#iri)**. The value of the IRI.|
+| property | description                                           |
+| -------- | ----------------------------------------------------- |
+| `type`   | _(Required.) _ **string**.                            |
+| `value`  | _(Required.) _ **[IRI](#iri)**. The value of the IRI. |
 
 ### Uint128
 
 A string containing a 128-bit integer in decimal representation.
 
-|type|
-|----|
-|**string**.|
+| type        |
+| ----------- |
+| **string**. |
 
 ### Value
 
-
-
-|variant|description|
-|-------|-----------|
-|[URI](#uri)|**object**. Represents an IRI.|
-|[Literal](#literal)|**object**. Represents a literal S with optional language tag L or datatype IRI D.|
-|[BlankNode](#blanknode)|**object**. Represents a blank node.|
+| variant                 | description                                                                        |
+| ----------------------- | ---------------------------------------------------------------------------------- |
+| [URI](#uri)             | **object**. Represents an IRI.                                                     |
+| [Literal](#literal)     | **object**. Represents a literal S with optional language tag L or datatype IRI D. |
+| [BlankNode](#blanknode) | **object**. Represents a blank node.                                               |
 
 ### VarOrNamedNode
 
 Represents either a variable or a named node (IRI).
 
-|variant|description|
-|-------|-----------|
-|[Variable](#variable)|**object**. A variable.|
-|[NamedNode](#namednode)|**object**. An RDF [IRI](https://www.w3.org/TR/rdf11-concepts/#dfn-iri).|
+| variant                 | description                                                              |
+| ----------------------- | ------------------------------------------------------------------------ |
+| [Variable](#variable)   | **object**. A variable.                                                  |
+| [NamedNode](#namednode) | **object**. An RDF [IRI](https://www.w3.org/TR/rdf11-concepts/#dfn-iri). |
 
 ### VarOrNode
 
 Represents either a variable or a node.
 
-|variant|description|
-|-------|-----------|
-|[Variable](#variable)|**object**. A variable.|
-|[Node](#node)|**object**. A node, i.e. an IRI or a blank node.|
+| variant               | description                                      |
+| --------------------- | ------------------------------------------------ |
+| [Variable](#variable) | **object**. A variable.                          |
+| [Node](#node)         | **object**. A node, i.e. an IRI or a blank node. |
 
 ### VarOrNodeOrLiteral
 
 Represents either a variable, a node or a literal.
 
-|variant|description|
-|-------|-----------|
-|[Variable](#variable)|**object**. A variable.|
-|[Node](#node)|**object**. A node, i.e. an IRI or a blank node.|
-|[Literal](#literal)|**object**. An RDF [literal](https://www.w3.org/TR/rdf11-concepts/#dfn-literal), i.e. a simple literal, a language-tagged string or a typed value.|
+| variant               | description                                                                                                                                        |
+| --------------------- | -------------------------------------------------------------------------------------------------------------------------------------------------- |
+| [Variable](#variable) | **object**. A variable.                                                                                                                            |
+| [Node](#node)         | **object**. A node, i.e. an IRI or a blank node.                                                                                                   |
+| [Literal](#literal)   | **object**. An RDF [literal](https://www.w3.org/TR/rdf11-concepts/#dfn-literal), i.e. a simple literal, a language-tagged string or a typed value. |
 
 ### Variable
 
 A variable.
 
-|property|description|
-|----------|-----------|
-|`variable`|*(Required.) * **string**. |
+| property   | description                |
+| ---------- | -------------------------- |
+| `variable` | _(Required.) _ **string**. |
 
 ### WhereCondition
 
 Represents a condition in a [WhereClause].
 
-|variant|description|
-|-------|-----------|
-|[Simple](#simple)|**object**. Represents a simple condition.|
+| variant           | description                                |
+| ----------------- | ------------------------------------------ |
+| [Simple](#simple) | **object**. Represents a simple condition. |
 
 ---
 
-*Rendered by [Fadroma](https://fadroma.tech) ([@fadroma/schema 1.1.0](https://www.npmjs.com/package/@fadroma/schema)) from `okp4-cognitarium.json` (`0b746186a6e8df78`)*
+_Rendered by [Fadroma](https://fadroma.tech) ([@fadroma/schema 1.1.0](https://www.npmjs.com/package/@fadroma/schema)) from `okp4-cognitarium.json` (`0b746186a6e8df78`)_

--- a/docs/okp4-dataverse.md
+++ b/docs/okp4-dataverse.md
@@ -47,12 +47,12 @@ Given its role and status, this smart contract serves as the primary access poin
 
 `InstantiateMsg` is used to initialize a new instance of the dataverse.
 
-|parameter|description|
-|----------|-----------|
-|`name`|*(Required.) * **string**. A unique name to identify the dataverse instance.|
-|`triplestore_config`|*(Required.) * **[TripleStoreConfig](#triplestoreconfig)**. The configuration used to instantiate the triple store.|
-|`triplestore_config.code_id`|**[Uint64](#uint64)**. The code id that will be used to instantiate the triple store contract in which to store dataverse semantic data. It must implement the cognitarium interface.|
-|`triplestore_config.limits`|**[TripleStoreLimitsInput](#triplestorelimitsinput)**. Limitations regarding triple store usage.|
+| parameter                    | description                                                                                                                                                                           |
+| ---------------------------- | ------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
+| `name`                       | _(Required.) _ **string**. A unique name to identify the dataverse instance.                                                                                                          |
+| `triplestore_config`         | _(Required.) _ **[TripleStoreConfig](#triplestoreconfig)**. The configuration used to instantiate the triple store.                                                                   |
+| `triplestore_config.code_id` | **[Uint64](#uint64)**. The code id that will be used to instantiate the triple store contract in which to store dataverse semantic data. It must implement the cognitarium interface. |
+| `triplestore_config.limits`  | **[TripleStoreLimitsInput](#triplestorelimitsinput)**. Limitations regarding triple store usage.                                                                                      |
 
 ## ExecuteMsg
 
@@ -86,11 +86,11 @@ To maintain integrity and coherence in the dataverse, several preconditions are 
 
 3. **Issuer Signature**: Claims must bear the issuer's signature. This signature must be verifiable, ensuring authenticity and credibility.
 
-|parameter|description|
-|----------|-----------|
-|`submit_claims`|*(Required.) * **object**. |
-|`submit_claims.format`|**[RdfFormat](#rdfformat)\|null**. RDF format in which the metadata is represented. If not provided, the default format is [Turtle](https://www.w3.org/TR/turtle/) format.|
-|`submit_claims.metadata`|*(Required.) * **[Binary](#binary)**. The serialized metadata intended for attachment. This metadata should adhere to the format specified in the `format` field.|
+| parameter                | description                                                                                                                                                                |
+| ------------------------ | -------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
+| `submit_claims`          | _(Required.) _ **object**.                                                                                                                                                 |
+| `submit_claims.format`   | **[RdfFormat](#rdfformat)\|null**. RDF format in which the metadata is represented. If not provided, the default format is [Turtle](https://www.w3.org/TR/turtle/) format. |
+| `submit_claims.metadata` | _(Required.) _ **[Binary](#binary)**. The serialized metadata intended for attachment. This metadata should adhere to the format specified in the `format` field.          |
 
 ### ExecuteMsg::RevokeClaims
 
@@ -100,10 +100,10 @@ Revoke or withdraw a previously submitted claims.
 
 1. **Identifier Existance**: The identifier of the claims must exist in the dataverse.
 
-|parameter|description|
-|----------|-----------|
-|`revoke_claims`|*(Required.) * **object**. |
-|`revoke_claims.identifier`|*(Required.) * **string**. The unique identifier of the claims to be revoked.|
+| parameter                  | description                                                                   |
+| -------------------------- | ----------------------------------------------------------------------------- |
+| `revoke_claims`            | _(Required.) _ **object**.                                                    |
+| `revoke_claims.identifier` | _(Required.) _ **string**. The unique identifier of the claims to be revoked. |
 
 ## QueryMsg
 
@@ -115,9 +115,9 @@ This enum provides variants for querying the dataverse's details and other relat
 
 Retrieves information about the current dataverse instance.
 
-|parameter|description|
-|----------|-----------|
-|`dataverse`|*(Required.) * **object**. |
+| parameter   | description                |
+| ----------- | -------------------------- |
+| `dataverse` | _(Required.) _ **object**. |
 
 ## Responses
 
@@ -125,9 +125,9 @@ Retrieves information about the current dataverse instance.
 
 DataverseResponse is the response of the Dataverse query.
 
-|property|description|
-|----------|-----------|
-|`name`|*(Required.) * **string**. The name of the dataverse.|
+| property | description                                           |
+| -------- | ----------------------------------------------------- |
+| `name`   | _(Required.) _ **string**. The name of the dataverse. |
 
 ## Definitions
 
@@ -135,9 +135,9 @@ DataverseResponse is the response of the Dataverse query.
 
 A string containing Base64-encoded data.
 
-|type|
-|----|
-|**string**.|
+| type        |
+| ----------- |
+| **string**. |
 
 ### NQuads
 
@@ -145,9 +145,9 @@ N-Quads Format
 
 N-Quads is an extension of N-Triples to support RDF datasets by adding an optional fourth element to represent the graph name. See the [official N-Quads specification](https://www.w3.org/TR/n-quads/).
 
-|literal|
-|-------|
-|`"n_quads"`|
+| literal     |
+| ----------- |
+| `"n_quads"` |
 
 ### NTriples
 
@@ -155,20 +155,20 @@ N-Triples Format
 
 N-Triples is a line-based, plain text format for encoding an RDF graph. Each line corresponds to a single RDF triple. See the [official N-Triples specification](https://www.w3.org/TR/n-triples/).
 
-|literal|
-|-------|
-|`"n_triples"`|
+| literal       |
+| ------------- |
+| `"n_triples"` |
 
 ### RdfFormat
 
 `RdfFormat` represents the various serialization formats for RDF (Resource Description Framework) data.
 
-|variant|description|
-|-------|-----------|
-|[RdfXml](#rdfxml)|**string**: `rdf_xml`. RDF/XML Format<br /><br />RDF/XML is a syntax to express RDF information in XML. See the [official RDF/XML specification](https://www.w3.org/TR/rdf-syntax-grammar/).|
-|[Turtle](#turtle)|**string**: `turtle`. Turtle (Terse RDF Triple Language) Format<br /><br />Turtle is a textual format for representing RDF triples in a more compact and human-readable way compared to RDF/XML. See the [official Turtle specification](https://www.w3.org/TR/turtle/).|
-|[NTriples](#ntriples)|**string**: `n_triples`. N-Triples Format<br /><br />N-Triples is a line-based, plain text format for encoding an RDF graph. Each line corresponds to a single RDF triple. See the [official N-Triples specification](https://www.w3.org/TR/n-triples/).|
-|[NQuads](#nquads)|**string**: `n_quads`. N-Quads Format<br /><br />N-Quads is an extension of N-Triples to support RDF datasets by adding an optional fourth element to represent the graph name. See the [official N-Quads specification](https://www.w3.org/TR/n-quads/).|
+| variant               | description                                                                                                                                                                                                                                                              |
+| --------------------- | ------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------ |
+| [RdfXml](#rdfxml)     | **string**: `rdf_xml`. RDF/XML Format<br /><br />RDF/XML is a syntax to express RDF information in XML. See the [official RDF/XML specification](https://www.w3.org/TR/rdf-syntax-grammar/).                                                                             |
+| [Turtle](#turtle)     | **string**: `turtle`. Turtle (Terse RDF Triple Language) Format<br /><br />Turtle is a textual format for representing RDF triples in a more compact and human-readable way compared to RDF/XML. See the [official Turtle specification](https://www.w3.org/TR/turtle/). |
+| [NTriples](#ntriples) | **string**: `n_triples`. N-Triples Format<br /><br />N-Triples is a line-based, plain text format for encoding an RDF graph. Each line corresponds to a single RDF triple. See the [official N-Triples specification](https://www.w3.org/TR/n-triples/).                 |
+| [NQuads](#nquads)     | **string**: `n_quads`. N-Quads Format<br /><br />N-Quads is an extension of N-Triples to support RDF datasets by adding an optional fourth element to represent the graph name. See the [official N-Quads specification](https://www.w3.org/TR/n-quads/).                |
 
 ### RdfXml
 
@@ -176,39 +176,39 @@ RDF/XML Format
 
 RDF/XML is a syntax to express RDF information in XML. See the [official RDF/XML specification](https://www.w3.org/TR/rdf-syntax-grammar/).
 
-|literal|
-|-------|
-|`"rdf_xml"`|
+| literal     |
+| ----------- |
+| `"rdf_xml"` |
 
 ### TripleStoreConfig
 
 `TripleStoreConfig` represents the configuration related to the management of the triple store.
 
-|property|description|
-|----------|-----------|
-|`code_id`|*(Required.) * **[Uint64](#uint64)**. The code id that will be used to instantiate the triple store contract in which to store dataverse semantic data. It must implement the cognitarium interface.|
-|`limits`|*(Required.) * **[TripleStoreLimitsInput](#triplestorelimitsinput)**. Limitations regarding triple store usage.|
-|`limits.max_byte_size`|**[Uint128](#uint128)\|null**. The maximum number of bytes the store can contain. The size of a triple is counted as the sum of the size of its subject, predicate and object, including the size of data types and language tags if any. Default to [Uint128::MAX] if not set, which can be considered as no limit.|
-|`limits.max_insert_data_byte_size`|**[Uint128](#uint128)\|null**. The maximum number of bytes an insert data query can contain. Default to [Uint128::MAX] if not set, which can be considered as no limit.|
-|`limits.max_insert_data_triple_count`|**[Uint128](#uint128)\|null**. The maximum number of triples an insert data query can contain (after parsing). Default to [Uint128::MAX] if not set, which can be considered as no limit.|
-|`limits.max_query_limit`|**integer\|null**. The maximum limit of a query, i.e. the maximum number of triples returned by a select query. Default to 30 if not set.|
-|`limits.max_query_variable_count`|**integer\|null**. The maximum number of variables a query can select. Default to 30 if not set.|
-|`limits.max_triple_byte_size`|**[Uint128](#uint128)\|null**. The maximum number of bytes the store can contain for a single triple. The size of a triple is counted as the sum of the size of its subject, predicate and object, including the size of data types and language tags if any. The limit is used to prevent storing very large triples, especially literals. Default to [Uint128::MAX] if not set, which can be considered as no limit.|
-|`limits.max_triple_count`|**[Uint128](#uint128)\|null**. The maximum number of triples the store can contain. Default to [Uint128::MAX] if not set, which can be considered as no limit.|
+| property                              | description                                                                                                                                                                                                                                                                                                                                                                                                            |
+| ------------------------------------- | ---------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
+| `code_id`                             | _(Required.) _ **[Uint64](#uint64)**. The code id that will be used to instantiate the triple store contract in which to store dataverse semantic data. It must implement the cognitarium interface.                                                                                                                                                                                                                   |
+| `limits`                              | _(Required.) _ **[TripleStoreLimitsInput](#triplestorelimitsinput)**. Limitations regarding triple store usage.                                                                                                                                                                                                                                                                                                        |
+| `limits.max_byte_size`                | **[Uint128](#uint128)\|null**. The maximum number of bytes the store can contain. The size of a triple is counted as the sum of the size of its subject, predicate and object, including the size of data types and language tags if any. Default to [Uint128::MAX] if not set, which can be considered as no limit.                                                                                                   |
+| `limits.max_insert_data_byte_size`    | **[Uint128](#uint128)\|null**. The maximum number of bytes an insert data query can contain. Default to [Uint128::MAX] if not set, which can be considered as no limit.                                                                                                                                                                                                                                                |
+| `limits.max_insert_data_triple_count` | **[Uint128](#uint128)\|null**. The maximum number of triples an insert data query can contain (after parsing). Default to [Uint128::MAX] if not set, which can be considered as no limit.                                                                                                                                                                                                                              |
+| `limits.max_query_limit`              | **integer\|null**. The maximum limit of a query, i.e. the maximum number of triples returned by a select query. Default to 30 if not set.                                                                                                                                                                                                                                                                              |
+| `limits.max_query_variable_count`     | **integer\|null**. The maximum number of variables a query can select. Default to 30 if not set.                                                                                                                                                                                                                                                                                                                       |
+| `limits.max_triple_byte_size`         | **[Uint128](#uint128)\|null**. The maximum number of bytes the store can contain for a single triple. The size of a triple is counted as the sum of the size of its subject, predicate and object, including the size of data types and language tags if any. The limit is used to prevent storing very large triples, especially literals. Default to [Uint128::MAX] if not set, which can be considered as no limit. |
+| `limits.max_triple_count`             | **[Uint128](#uint128)\|null**. The maximum number of triples the store can contain. Default to [Uint128::MAX] if not set, which can be considered as no limit.                                                                                                                                                                                                                                                         |
 
 ### TripleStoreLimitsInput
 
 Contains requested limitations regarding store usages.
 
-|property|description|
-|----------|-----------|
-|`max_byte_size`|**[Uint128](#uint128)\|null**. The maximum number of bytes the store can contain. The size of a triple is counted as the sum of the size of its subject, predicate and object, including the size of data types and language tags if any. Default to [Uint128::MAX] if not set, which can be considered as no limit.|
-|`max_insert_data_byte_size`|**[Uint128](#uint128)\|null**. The maximum number of bytes an insert data query can contain. Default to [Uint128::MAX] if not set, which can be considered as no limit.|
-|`max_insert_data_triple_count`|**[Uint128](#uint128)\|null**. The maximum number of triples an insert data query can contain (after parsing). Default to [Uint128::MAX] if not set, which can be considered as no limit.|
-|`max_query_limit`|**integer\|null**. The maximum limit of a query, i.e. the maximum number of triples returned by a select query. Default to 30 if not set.|
-|`max_query_variable_count`|**integer\|null**. The maximum number of variables a query can select. Default to 30 if not set.|
-|`max_triple_byte_size`|**[Uint128](#uint128)\|null**. The maximum number of bytes the store can contain for a single triple. The size of a triple is counted as the sum of the size of its subject, predicate and object, including the size of data types and language tags if any. The limit is used to prevent storing very large triples, especially literals. Default to [Uint128::MAX] if not set, which can be considered as no limit.|
-|`max_triple_count`|**[Uint128](#uint128)\|null**. The maximum number of triples the store can contain. Default to [Uint128::MAX] if not set, which can be considered as no limit.|
+| property                       | description                                                                                                                                                                                                                                                                                                                                                                                                            |
+| ------------------------------ | ---------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
+| `max_byte_size`                | **[Uint128](#uint128)\|null**. The maximum number of bytes the store can contain. The size of a triple is counted as the sum of the size of its subject, predicate and object, including the size of data types and language tags if any. Default to [Uint128::MAX] if not set, which can be considered as no limit.                                                                                                   |
+| `max_insert_data_byte_size`    | **[Uint128](#uint128)\|null**. The maximum number of bytes an insert data query can contain. Default to [Uint128::MAX] if not set, which can be considered as no limit.                                                                                                                                                                                                                                                |
+| `max_insert_data_triple_count` | **[Uint128](#uint128)\|null**. The maximum number of triples an insert data query can contain (after parsing). Default to [Uint128::MAX] if not set, which can be considered as no limit.                                                                                                                                                                                                                              |
+| `max_query_limit`              | **integer\|null**. The maximum limit of a query, i.e. the maximum number of triples returned by a select query. Default to 30 if not set.                                                                                                                                                                                                                                                                              |
+| `max_query_variable_count`     | **integer\|null**. The maximum number of variables a query can select. Default to 30 if not set.                                                                                                                                                                                                                                                                                                                       |
+| `max_triple_byte_size`         | **[Uint128](#uint128)\|null**. The maximum number of bytes the store can contain for a single triple. The size of a triple is counted as the sum of the size of its subject, predicate and object, including the size of data types and language tags if any. The limit is used to prevent storing very large triples, especially literals. Default to [Uint128::MAX] if not set, which can be considered as no limit. |
+| `max_triple_count`             | **[Uint128](#uint128)\|null**. The maximum number of triples the store can contain. Default to [Uint128::MAX] if not set, which can be considered as no limit.                                                                                                                                                                                                                                                         |
 
 ### Turtle
 
@@ -216,17 +216,17 @@ Turtle (Terse RDF Triple Language) Format
 
 Turtle is a textual format for representing RDF triples in a more compact and human-readable way compared to RDF/XML. See the [official Turtle specification](https://www.w3.org/TR/turtle/).
 
-|literal|
-|-------|
-|`"turtle"`|
+| literal    |
+| ---------- |
+| `"turtle"` |
 
 ### Uint128
 
 A string containing a 128-bit integer in decimal representation.
 
-|type|
-|----|
-|**string**.|
+| type        |
+| ----------- |
+| **string**. |
 
 ### Uint64
 
@@ -236,7 +236,7 @@ A thin wrapper around u64 that is using strings for JSON encoding/decoding, such
 
 Use `from` to create instances of this and `u64` to get the value out:
 
-``` # use cosmwasm_std::Uint64; let a = Uint64::from(42u64); assert_eq!(a.u64(), 42);
+````# use cosmwasm_std::Uint64; let a = Uint64::from(42u64); assert_eq!(a.u64(), 42);
 
 let b = Uint64::from(70u32); assert_eq!(b.u64(), 70); ```
 
@@ -247,3 +247,4 @@ let b = Uint64::from(70u32); assert_eq!(b.u64(), 70); ```
 ---
 
 *Rendered by [Fadroma](https://fadroma.tech) ([@fadroma/schema 1.1.0](https://www.npmjs.com/package/@fadroma/schema)) from `okp4-dataverse.json` (`2a5c7ef038c6b263`)*
+````

--- a/docs/okp4-law-stone.md
+++ b/docs/okp4-law-stone.md
@@ -18,10 +18,10 @@ To be able to free the underlying resources (i.e. objects in `okp4-objectarium`)
 
 Instantiate message
 
-|parameter|description|
-|----------|-----------|
-|`program`|*(Required.) * **[Binary](#binary)**. The Prolog program carrying law rules and facts.|
-|`storage_address`|*(Required.) * **string**. The `okp4-objectarium` contract address on which to store the law program.|
+| parameter         | description                                                                                           |
+| ----------------- | ----------------------------------------------------------------------------------------------------- |
+| `program`         | _(Required.) _ **[Binary](#binary)**. The Prolog program carrying law rules and facts.                |
+| `storage_address` | _(Required.) _ **string**. The `okp4-objectarium` contract address on which to store the law program. |
 
 ## ExecuteMsg
 
@@ -31,9 +31,9 @@ Execute messages
 
 Break the stone making this contract unusable, by clearing all the related resources: - Unpin all the pinned objects on `okp4-objectarium` contracts, if any. - Forget the main program (i.e. or at least unpin it). Only the contract admin is authorized to break it, if any. If already broken, this is a no-op.
 
-|literal|
-|-------|
-|`"break_stone"`|
+| literal         |
+| --------------- |
+| `"break_stone"` |
 
 ## QueryMsg
 
@@ -43,105 +43,95 @@ Query messages
 
 If not broken, ask the logic module the provided query with the law program loaded.
 
-|parameter|description|
-|----------|-----------|
-|`ask`|*(Required.) * **object**. |
-|`ask.query`|*(Required.) * **string**. |
+| parameter   | description                |
+| ----------- | -------------------------- |
+| `ask`       | _(Required.) _ **object**. |
+| `ask.query` | _(Required.) _ **string**. |
 
 ### QueryMsg::Program
 
 If not broken, returns the law program location information.
 
-|literal|
-|-------|
-|`"program"`|
+| literal     |
+| ----------- |
+| `"program"` |
 
 ### QueryMsg::ProgramCode
 
 ProgramCode returns the law program code.
 
-|literal|
-|-------|
-|`"program_code"`|
+| literal          |
+| ---------------- |
+| `"program_code"` |
 
 ## Responses
 
 ### ask
 
-
-
-|property|description|
-|----------|-----------|
-|`answer`|**[Answer](#answer)\|null**. |
-|`gas_used`|*(Required.) * **integer**. |
-|`height`|*(Required.) * **integer**. |
+| property   | description                  |
+| ---------- | ---------------------------- |
+| `answer`   | **[Answer](#answer)\|null**. |
+| `gas_used` | _(Required.) _ **integer**.  |
+| `height`   | _(Required.) _ **integer**.  |
 
 ### program
 
 ProgramResponse carry elements to locate the program in a `okp4-objectarium` contract.
 
-|property|description|
-|----------|-----------|
-|`object_id`|*(Required.) * **string**. The program object id in the `okp4-objectarium` contract.|
-|`storage_address`|*(Required.) * **string**. The `okp4-objectarium` contract address on which the law program is stored.|
+| property          | description                                                                                            |
+| ----------------- | ------------------------------------------------------------------------------------------------------ |
+| `object_id`       | _(Required.) _ **string**. The program object id in the `okp4-objectarium` contract.                   |
+| `storage_address` | _(Required.) _ **string**. The `okp4-objectarium` contract address on which the law program is stored. |
 
 ### program_code
 
 Binary is a wrapper around Vec&lt;u8&gt; to add base64 de/serialization with serde. It also adds some helper methods to help encode inline.
 
-This is only needed as serde-json-{core,wasm} has a horrible encoding for Vec&lt;u8&gt;. See also &lt;https://github.com/CosmWasm/cosmwasm/blob/main/docs/MESSAGE_TYPES.md&gt;.
+This is only needed as serde-json-\{core,wasm\} has a horrible encoding for Vec&lt;u8&gt;. See also &lt;https://github.com/CosmWasm/cosmwasm/blob/main/docs/MESSAGE_TYPES.md&gt;.
 
-|type|
-|----|
-|**string**.|
+| type        |
+| ----------- |
+| **string**. |
 
 ## Definitions
 
 ### Answer
 
-
-
-|property|description|
-|----------|-----------|
-|`has_more`|*(Required.) * **boolean**. |
-|`results`|*(Required.) * **Array&lt;[Result](#result)&gt;**. |
-|`success`|*(Required.) * **boolean**. |
-|`variables`|*(Required.) * **Array&lt;string&gt;**. |
+| property    | description                                        |
+| ----------- | -------------------------------------------------- |
+| `has_more`  | _(Required.) _ **boolean**.                        |
+| `results`   | _(Required.) _ **Array&lt;[Result](#result)&gt;**. |
+| `success`   | _(Required.) _ **boolean**.                        |
+| `variables` | _(Required.) _ **Array&lt;string&gt;**.            |
 
 ### Binary
 
 A string containing Base64-encoded data.
 
-|type|
-|----|
-|**string**.|
+| type        |
+| ----------- |
+| **string**. |
 
 ### Result
 
-
-
-|property|description|
-|----------|-----------|
-|`substitutions`|*(Required.) * **Array&lt;[Substitution](#substitution)&gt;**. |
+| property        | description                                                    |
+| --------------- | -------------------------------------------------------------- |
+| `substitutions` | _(Required.) _ **Array&lt;[Substitution](#substitution)&gt;**. |
 
 ### Substitution
 
-
-
-|property|description|
-|----------|-----------|
-|`term`|*(Required.) * **object**. |
-|`variable`|*(Required.) * **string**. |
+| property   | description                |
+| ---------- | -------------------------- |
+| `term`     | _(Required.) _ **object**. |
+| `variable` | _(Required.) _ **string**. |
 
 ### Term
 
-
-
-|property|description|
-|----------|-----------|
-|`arguments`|*(Required.) * **Array&lt;[Term](#term)&gt;**. |
-|`name`|*(Required.) * **string**. |
+| property    | description                                    |
+| ----------- | ---------------------------------------------- |
+| `arguments` | _(Required.) _ **Array&lt;[Term](#term)&gt;**. |
+| `name`      | _(Required.) _ **string**.                     |
 
 ---
 
-*Rendered by [Fadroma](https://fadroma.tech) ([@fadroma/schema 1.1.0](https://www.npmjs.com/package/@fadroma/schema)) from `okp4-law-stone.json` (`092608edf6c36d25`)*
+_Rendered by [Fadroma](https://fadroma.tech) ([@fadroma/schema 1.1.0](https://www.npmjs.com/package/@fadroma/schema)) from `okp4-law-stone.json` (`092608edf6c36d25`)_

--- a/docs/okp4-objectarium.md
+++ b/docs/okp4-objectarium.md
@@ -23,7 +23,7 @@ Features like pinning, unpinning, and discarding objects offer a strategic way t
 
 ## Rationale
 
-In a sense, we can consider blockchains built on the [Cosmos L0](https://docs.cosmos.network/main) layer as decentralized databases, and their nature can be shaped and modeled through the smart contracts or modules. Given this, it provides a great opportunity to address the wide range of data management needs. One such important area is the management of unstructured, immutable data, which is written once but accessed frequently — commonly known as object storage. This is the primary focus of `okp4-objectarium`: a specialized smart contract designed to offer a versatile and efficient approach to handling *on-chain*, *unstructured*, *immutable* data in a *decentralized* manner.
+In a sense, we can consider blockchains built on the [Cosmos L0](https://docs.cosmos.network/main) layer as decentralized databases, and their nature can be shaped and modeled through the smart contracts or modules. Given this, it provides a great opportunity to address the wide range of data management needs. One such important area is the management of unstructured, immutable data, which is written once but accessed frequently — commonly known as object storage. This is the primary focus of `okp4-objectarium`: a specialized smart contract designed to offer a versatile and efficient approach to handling _on-chain_, _unstructured_, _immutable_ data in a _decentralized_ manner.
 
 ## Terminology
 
@@ -148,20 +148,20 @@ okp4d query wasm contract-state smart $CONTRACT_ADDR \
 
 Instantiate messages
 
-|parameter|description|
-|----------|-----------|
-|`bucket`|*(Required.) * **string**. The name of the bucket. The name could not be empty or contains whitespaces. If name contains whitespace, they will be removed.|
-|`config`|**[BucketConfig](#bucketconfig)**. The configuration of the bucket.|
-|`config.accepted_compression_algorithms`|**Array&lt;[CompressionAlgorithm](#compressionalgorithm)&gt;**. The acceptable compression algorithms for the objects in the bucket. If this parameter is not set (none or empty array), then all compression algorithms are accepted. If this parameter is set, then only the compression algorithms in the array are accepted.<br /><br />When an object is stored in the bucket without a specified compression algorithm, the first algorithm in the array is used. Therefore, the order of the algorithms in the array is significant. Typically, the most efficient compression algorithm, such as the NoCompression algorithm, should be placed first in the array.<br /><br />Any attempt to store an object using a different compression algorithm than the ones specified here will fail.<br />**Default:** `["passthrough","snappy","lzma"]`|
-|`config.hash_algorithm`|**[HashAlgorithm](#hashalgorithm)**. The algorithm used to hash the content of the objects to generate the id of the objects. The algorithm is optional and if not set, the default algorithm is used.<br /><br />The default algorithm is Sha256 if not set.<br />**Default:** `"sha256"`|
-|`limits`|**[BucketLimits](#bucketlimits)**. The limits of the bucket.|
-|`limits.max_object_pins`|**[Uint128](#uint128)\|null**. The maximum number of pins in the bucket for an object.|
-|`limits.max_object_size`|**[Uint128](#uint128)\|null**. The maximum size of the objects in the bucket.|
-|`limits.max_objects`|**[Uint128](#uint128)\|null**. The maximum number of objects in the bucket.|
-|`limits.max_total_size`|**[Uint128](#uint128)\|null**. The maximum total size of the objects in the bucket.|
-|`pagination`|**[PaginationConfig](#paginationconfig)**. The configuration for paginated query.|
-|`pagination.default_page_size`|**integer**. The default number of elements in a page.<br /><br />Shall be less or equal than `max_page_size`. Default to '10' if not set.<br />**Default:** `10`|
-|`pagination.max_page_size`|**integer**. The maximum elements a page can contain.<br /><br />Shall be less than `u32::MAX - 1`. Default to '30' if not set.<br />**Default:** `30`|
+| parameter                                | description                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                              |
+| ---------------------------------------- | -------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
+| `bucket`                                 | _(Required.) _ **string**. The name of the bucket. The name could not be empty or contains whitespaces. If name contains whitespace, they will be removed.                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                               |
+| `config`                                 | **[BucketConfig](#bucketconfig)**. The configuration of the bucket.                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                      |
+| `config.accepted_compression_algorithms` | **Array&lt;[CompressionAlgorithm](#compressionalgorithm)&gt;**. The acceptable compression algorithms for the objects in the bucket. If this parameter is not set (none or empty array), then all compression algorithms are accepted. If this parameter is set, then only the compression algorithms in the array are accepted.<br /><br />When an object is stored in the bucket without a specified compression algorithm, the first algorithm in the array is used. Therefore, the order of the algorithms in the array is significant. Typically, the most efficient compression algorithm, such as the NoCompression algorithm, should be placed first in the array.<br /><br />Any attempt to store an object using a different compression algorithm than the ones specified here will fail.<br />**Default:** `["passthrough","snappy","lzma"]` |
+| `config.hash_algorithm`                  | **[HashAlgorithm](#hashalgorithm)**. The algorithm used to hash the content of the objects to generate the id of the objects. The algorithm is optional and if not set, the default algorithm is used.<br /><br />The default algorithm is Sha256 if not set.<br />**Default:** `"sha256"`                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                               |
+| `limits`                                 | **[BucketLimits](#bucketlimits)**. The limits of the bucket.                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                             |
+| `limits.max_object_pins`                 | **[Uint128](#uint128)\|null**. The maximum number of pins in the bucket for an object.                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                   |
+| `limits.max_object_size`                 | **[Uint128](#uint128)\|null**. The maximum size of the objects in the bucket.                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                            |
+| `limits.max_objects`                     | **[Uint128](#uint128)\|null**. The maximum number of objects in the bucket.                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                              |
+| `limits.max_total_size`                  | **[Uint128](#uint128)\|null**. The maximum total size of the objects in the bucket.                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                      |
+| `pagination`                             | **[PaginationConfig](#paginationconfig)**. The configuration for paginated query.                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                        |
+| `pagination.default_page_size`           | **integer**. The default number of elements in a page.<br /><br />Shall be less or equal than `max_page_size`. Default to '10' if not set.<br />**Default:** `10`                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                        |
+| `pagination.max_page_size`               | **integer**. The maximum elements a page can contain.<br /><br />Shall be less than `u32::MAX - 1`. Default to '30' if not set.<br />**Default:** `30`                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                   |
 
 ## ExecuteMsg
 
@@ -175,39 +175,39 @@ The "pin" parameter specifies if the object should be pinned for the sender. In 
 
 The "compression_algorithm" parameter specifies the algorithm for compressing the object before storing it in the storage, which is optional. If no algorithm is specified, the algorithm used is the first algorithm of the bucket configuration limits. Note that the chosen algorithm can save storage space, but it will increase CPU usage. Depending on the chosen compression algorithm and the achieved compression ratio, the gas cost of the operation will vary, either increasing or decreasing.
 
-|parameter|description|
-|----------|-----------|
-|`store_object`|*(Required.) * **object**. |
-|`store_object.compression_algorithm`|**[CompressionAlgorithm](#compressionalgorithm)\|null**. Specifies the compression algorithm to use when storing the object. If None, the first algorithm specified in the list of accepted compression algorithms of the bucket is used (see [BucketLimits::accepted_compression_algorithms]).|
-|`store_object.data`|*(Required.) * **[Binary](#binary)**. The content of the object to store.|
-|`store_object.pin`|*(Required.) * **boolean**. Specifies if the object should be pinned for the sender.|
+| parameter                            | description                                                                                                                                                                                                                                                                                     |
+| ------------------------------------ | ----------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
+| `store_object`                       | _(Required.) _ **object**.                                                                                                                                                                                                                                                                      |
+| `store_object.compression_algorithm` | **[CompressionAlgorithm](#compressionalgorithm)\|null**. Specifies the compression algorithm to use when storing the object. If None, the first algorithm specified in the list of accepted compression algorithms of the bucket is used (see [BucketLimits::accepted_compression_algorithms]). |
+| `store_object.data`                  | _(Required.) _ **[Binary](#binary)**. The content of the object to store.                                                                                                                                                                                                                       |
+| `store_object.pin`                   | _(Required.) _ **boolean**. Specifies if the object should be pinned for the sender.                                                                                                                                                                                                            |
 
 ### ExecuteMsg::ForgetObject
 
 ForgetObject first unpin the object from the bucket for the considered sender, then remove it from the storage if it is not pinned anymore. If the object is pinned for other senders, it is not removed from the storage and an error is returned. If the object is not pinned for the sender, this is a no-op.
 
-|parameter|description|
-|----------|-----------|
-|`forget_object`|*(Required.) * **object**. |
-|`forget_object.id`|*(Required.) * **string**. |
+| parameter          | description                |
+| ------------------ | -------------------------- |
+| `forget_object`    | _(Required.) _ **object**. |
+| `forget_object.id` | _(Required.) _ **string**. |
 
 ### ExecuteMsg::PinObject
 
 PinObject pins the object in the bucket for the considered sender. If the object is already pinned for the sender, this is a no-op. While an object is pinned, it cannot be removed from the storage.
 
-|parameter|description|
-|----------|-----------|
-|`pin_object`|*(Required.) * **object**. |
-|`pin_object.id`|*(Required.) * **string**. |
+| parameter       | description                |
+| --------------- | -------------------------- |
+| `pin_object`    | _(Required.) _ **object**. |
+| `pin_object.id` | _(Required.) _ **string**. |
 
 ### ExecuteMsg::UnpinObject
 
 UnpinObject unpins the object in the bucket for the considered sender. If the object is not pinned for the sender, this is a no-op. The object can be removed from the storage if it is not pinned anymore.
 
-|parameter|description|
-|----------|-----------|
-|`unpin_object`|*(Required.) * **object**. |
-|`unpin_object.id`|*(Required.) * **string**. |
+| parameter         | description                |
+| ----------------- | -------------------------- |
+| `unpin_object`    | _(Required.) _ **object**. |
+| `unpin_object.id` | _(Required.) _ **string**. |
 
 ## QueryMsg
 
@@ -217,49 +217,49 @@ Query messages
 
 Bucket returns the bucket information.
 
-|parameter|description|
-|----------|-----------|
-|`bucket`|*(Required.) * **object**. |
+| parameter | description                |
+| --------- | -------------------------- |
+| `bucket`  | _(Required.) _ **object**. |
 
 ### QueryMsg::Object
 
 Object returns the object information with the given id.
 
-|parameter|description|
-|----------|-----------|
-|`object`|*(Required.) * **object**. |
-|`object.id`|*(Required.) * **string**. The id of the object to get.|
+| parameter   | description                                             |
+| ----------- | ------------------------------------------------------- |
+| `object`    | _(Required.) _ **object**.                              |
+| `object.id` | _(Required.) _ **string**. The id of the object to get. |
 
 ### QueryMsg::Objects
 
 Objects returns the list of objects in the bucket with support for pagination.
 
-|parameter|description|
-|----------|-----------|
-|`objects`|*(Required.) * **object**. |
-|`objects.address`|**string\|null**. The owner of the objects to get.|
-|`objects.after`|**string\|null**. The point in the sequence to start returning objects.|
-|`objects.first`|**integer\|null**. The number of objects to return.|
+| parameter         | description                                                             |
+| ----------------- | ----------------------------------------------------------------------- |
+| `objects`         | _(Required.) _ **object**.                                              |
+| `objects.address` | **string\|null**. The owner of the objects to get.                      |
+| `objects.after`   | **string\|null**. The point in the sequence to start returning objects. |
+| `objects.first`   | **integer\|null**. The number of objects to return.                     |
 
 ### QueryMsg::ObjectData
 
 ObjectData returns the content of the object with the given id.
 
-|parameter|description|
-|----------|-----------|
-|`object_data`|*(Required.) * **object**. |
-|`object_data.id`|*(Required.) * **string**. The id of the object to get.|
+| parameter        | description                                             |
+| ---------------- | ------------------------------------------------------- |
+| `object_data`    | _(Required.) _ **object**.                              |
+| `object_data.id` | _(Required.) _ **string**. The id of the object to get. |
 
 ### QueryMsg::ObjectPins
 
 ObjectPins returns the list of addresses that pinned the object with the given id with support for pagination.
 
-|parameter|description|
-|----------|-----------|
-|`object_pins`|*(Required.) * **object**. |
-|`object_pins.after`|**string\|null**. The point in the sequence to start returning pins.|
-|`object_pins.first`|**integer\|null**. The number of pins to return.|
-|`object_pins.id`|*(Required.) * **string**. The id of the object to get the pins for.|
+| parameter           | description                                                          |
+| ------------------- | -------------------------------------------------------------------- |
+| `object_pins`       | _(Required.) _ **object**.                                           |
+| `object_pins.after` | **string\|null**. The point in the sequence to start returning pins. |
+| `object_pins.first` | **integer\|null**. The number of pins to return.                     |
+| `object_pins.id`    | _(Required.) _ **string**. The id of the object to get the pins for. |
 
 ## Responses
 
@@ -267,65 +267,65 @@ ObjectPins returns the list of addresses that pinned the object with the given i
 
 BucketResponse is the response of the Bucket query.
 
-|property|description|
-|----------|-----------|
-|`config`|*(Required.) * **[BucketConfig](#bucketconfig)**. The configuration of the bucket.|
-|`config.accepted_compression_algorithms`|**Array&lt;[CompressionAlgorithm](#compressionalgorithm)&gt;**. The acceptable compression algorithms for the objects in the bucket. If this parameter is not set (none or empty array), then all compression algorithms are accepted. If this parameter is set, then only the compression algorithms in the array are accepted.<br /><br />When an object is stored in the bucket without a specified compression algorithm, the first algorithm in the array is used. Therefore, the order of the algorithms in the array is significant. Typically, the most efficient compression algorithm, such as the NoCompression algorithm, should be placed first in the array.<br /><br />Any attempt to store an object using a different compression algorithm than the ones specified here will fail.<br />**Default:** `["passthrough","snappy","lzma"]`|
-|`config.hash_algorithm`|**[HashAlgorithm](#hashalgorithm)**. The algorithm used to hash the content of the objects to generate the id of the objects. The algorithm is optional and if not set, the default algorithm is used.<br /><br />The default algorithm is Sha256 if not set.<br />**Default:** `"sha256"`|
-|`limits`|*(Required.) * **[BucketLimits](#bucketlimits)**. The limits of the bucket.|
-|`limits.max_object_pins`|**[Uint128](#uint128)\|null**. The maximum number of pins in the bucket for an object.|
-|`limits.max_object_size`|**[Uint128](#uint128)\|null**. The maximum size of the objects in the bucket.|
-|`limits.max_objects`|**[Uint128](#uint128)\|null**. The maximum number of objects in the bucket.|
-|`limits.max_total_size`|**[Uint128](#uint128)\|null**. The maximum total size of the objects in the bucket.|
-|`name`|*(Required.) * **string**. The name of the bucket.|
-|`pagination`|*(Required.) * **[PaginationConfig](#paginationconfig)**. The configuration for paginated query.|
-|`pagination.default_page_size`|**integer**. The default number of elements in a page.<br /><br />Shall be less or equal than `max_page_size`. Default to '10' if not set.<br />**Default:** `10`|
-|`pagination.max_page_size`|**integer**. The maximum elements a page can contain.<br /><br />Shall be less than `u32::MAX - 1`. Default to '30' if not set.<br />**Default:** `30`|
+| property                                 | description                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                              |
+| ---------------------------------------- | -------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
+| `config`                                 | _(Required.) _ **[BucketConfig](#bucketconfig)**. The configuration of the bucket.                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                       |
+| `config.accepted_compression_algorithms` | **Array&lt;[CompressionAlgorithm](#compressionalgorithm)&gt;**. The acceptable compression algorithms for the objects in the bucket. If this parameter is not set (none or empty array), then all compression algorithms are accepted. If this parameter is set, then only the compression algorithms in the array are accepted.<br /><br />When an object is stored in the bucket without a specified compression algorithm, the first algorithm in the array is used. Therefore, the order of the algorithms in the array is significant. Typically, the most efficient compression algorithm, such as the NoCompression algorithm, should be placed first in the array.<br /><br />Any attempt to store an object using a different compression algorithm than the ones specified here will fail.<br />**Default:** `["passthrough","snappy","lzma"]` |
+| `config.hash_algorithm`                  | **[HashAlgorithm](#hashalgorithm)**. The algorithm used to hash the content of the objects to generate the id of the objects. The algorithm is optional and if not set, the default algorithm is used.<br /><br />The default algorithm is Sha256 if not set.<br />**Default:** `"sha256"`                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                               |
+| `limits`                                 | _(Required.) _ **[BucketLimits](#bucketlimits)**. The limits of the bucket.                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                              |
+| `limits.max_object_pins`                 | **[Uint128](#uint128)\|null**. The maximum number of pins in the bucket for an object.                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                   |
+| `limits.max_object_size`                 | **[Uint128](#uint128)\|null**. The maximum size of the objects in the bucket.                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                            |
+| `limits.max_objects`                     | **[Uint128](#uint128)\|null**. The maximum number of objects in the bucket.                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                              |
+| `limits.max_total_size`                  | **[Uint128](#uint128)\|null**. The maximum total size of the objects in the bucket.                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                      |
+| `name`                                   | _(Required.) _ **string**. The name of the bucket.                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                       |
+| `pagination`                             | _(Required.) _ **[PaginationConfig](#paginationconfig)**. The configuration for paginated query.                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                         |
+| `pagination.default_page_size`           | **integer**. The default number of elements in a page.<br /><br />Shall be less or equal than `max_page_size`. Default to '10' if not set.<br />**Default:** `10`                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                        |
+| `pagination.max_page_size`               | **integer**. The maximum elements a page can contain.<br /><br />Shall be less than `u32::MAX - 1`. Default to '30' if not set.<br />**Default:** `30`                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                   |
 
 ### object
 
 ObjectResponse is the response of the Object query.
 
-|property|description|
-|----------|-----------|
-|`compressed_size`|*(Required.) * **[Uint128](#uint128)**. The size of the object when compressed. If the object is not compressed, the value is the same as `size`.|
-|`compression_algorithm`|*(Required.) * **[CompressionAlgorithm](#compressionalgorithm)**. The compression algorithm used to compress the content of the object.|
-|`id`|*(Required.) * **string**. The id of the object.|
-|`is_pinned`|*(Required.) * **boolean**. Tells if the object is pinned by at least one address.|
-|`owner`|*(Required.) * **string**. The owner of the object.|
-|`size`|*(Required.) * **[Uint128](#uint128)**. The size of the object.|
+| property                | description                                                                                                                                       |
+| ----------------------- | ------------------------------------------------------------------------------------------------------------------------------------------------- |
+| `compressed_size`       | _(Required.) _ **[Uint128](#uint128)**. The size of the object when compressed. If the object is not compressed, the value is the same as `size`. |
+| `compression_algorithm` | _(Required.) _ **[CompressionAlgorithm](#compressionalgorithm)**. The compression algorithm used to compress the content of the object.           |
+| `id`                    | _(Required.) _ **string**. The id of the object.                                                                                                  |
+| `is_pinned`             | _(Required.) _ **boolean**. Tells if the object is pinned by at least one address.                                                                |
+| `owner`                 | _(Required.) _ **string**. The owner of the object.                                                                                               |
+| `size`                  | _(Required.) _ **[Uint128](#uint128)**. The size of the object.                                                                                   |
 
 ### object_data
 
 Binary is a wrapper around Vec&lt;u8&gt; to add base64 de/serialization with serde. It also adds some helper methods to help encode inline.
 
-This is only needed as serde-json-{core,wasm} has a horrible encoding for Vec&lt;u8&gt;. See also &lt;https://github.com/CosmWasm/cosmwasm/blob/main/docs/MESSAGE_TYPES.md&gt;.
+This is only needed as serde-json-\{core,wasm\} has a horrible encoding for Vec&lt;u8&gt;. See also &lt;https://github.com/CosmWasm/cosmwasm/blob/main/docs/MESSAGE_TYPES.md&gt;.
 
-|type|
-|----|
-|**string**.|
+| type        |
+| ----------- |
+| **string**. |
 
 ### object_pins
 
 ObjectPinsResponse is the response of the GetObjectPins query.
 
-|property|description|
-|----------|-----------|
-|`data`|*(Required.) * **Array&lt;string&gt;**. The list of addresses that pinned the object.|
-|`page_info`|*(Required.) * **[PageInfo](#pageinfo)**. The page information.|
-|`page_info.cursor`|**string**. The cursor to the next page.|
-|`page_info.has_next_page`|**boolean**. Tells if there is a next page.|
+| property                  | description                                                                           |
+| ------------------------- | ------------------------------------------------------------------------------------- |
+| `data`                    | _(Required.) _ **Array&lt;string&gt;**. The list of addresses that pinned the object. |
+| `page_info`               | _(Required.) _ **[PageInfo](#pageinfo)**. The page information.                       |
+| `page_info.cursor`        | **string**. The cursor to the next page.                                              |
+| `page_info.has_next_page` | **boolean**. Tells if there is a next page.                                           |
 
 ### objects
 
 ObjectsResponse is the response of the Objects query.
 
-|property|description|
-|----------|-----------|
-|`data`|*(Required.) * **Array&lt;[ObjectResponse](#objectresponse)&gt;**. The list of objects in the bucket.|
-|`page_info`|*(Required.) * **[PageInfo](#pageinfo)**. The page information.|
-|`page_info.cursor`|**string**. The cursor to the next page.|
-|`page_info.has_next_page`|**boolean**. Tells if there is a next page.|
+| property                  | description                                                                                           |
+| ------------------------- | ----------------------------------------------------------------------------------------------------- |
+| `data`                    | _(Required.) _ **Array&lt;[ObjectResponse](#objectresponse)&gt;**. The list of objects in the bucket. |
+| `page_info`               | _(Required.) _ **[PageInfo](#pageinfo)**. The page information.                                       |
+| `page_info.cursor`        | **string**. The cursor to the next page.                                                              |
+| `page_info.has_next_page` | **boolean**. Tells if there is a next page.                                                           |
 
 ## Definitions
 
@@ -333,9 +333,9 @@ ObjectsResponse is the response of the Objects query.
 
 A string containing Base64-encoded data.
 
-|type|
-|----|
-|**string**.|
+| type        |
+| ----------- |
+| **string**. |
 
 ### BucketConfig
 
@@ -343,10 +343,10 @@ BucketConfig is the type of the configuration of a bucket.
 
 The configuration is set at the instantiation of the bucket, and is immutable and cannot be changed. The configuration is optional and if not set, the default configuration is used.
 
-|property|description|
-|----------|-----------|
-|`accepted_compression_algorithms`|**Array&lt;[CompressionAlgorithm](#compressionalgorithm)&gt;**. The acceptable compression algorithms for the objects in the bucket. If this parameter is not set (none or empty array), then all compression algorithms are accepted. If this parameter is set, then only the compression algorithms in the array are accepted.<br /><br />When an object is stored in the bucket without a specified compression algorithm, the first algorithm in the array is used. Therefore, the order of the algorithms in the array is significant. Typically, the most efficient compression algorithm, such as the NoCompression algorithm, should be placed first in the array.<br /><br />Any attempt to store an object using a different compression algorithm than the ones specified here will fail.|
-|`hash_algorithm`|**[HashAlgorithm](#hashalgorithm)**. The algorithm used to hash the content of the objects to generate the id of the objects. The algorithm is optional and if not set, the default algorithm is used.<br /><br />The default algorithm is Sha256 if not set.|
+| property                          | description                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                          |
+| --------------------------------- | ---------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
+| `accepted_compression_algorithms` | **Array&lt;[CompressionAlgorithm](#compressionalgorithm)&gt;**. The acceptable compression algorithms for the objects in the bucket. If this parameter is not set (none or empty array), then all compression algorithms are accepted. If this parameter is set, then only the compression algorithms in the array are accepted.<br /><br />When an object is stored in the bucket without a specified compression algorithm, the first algorithm in the array is used. Therefore, the order of the algorithms in the array is significant. Typically, the most efficient compression algorithm, such as the NoCompression algorithm, should be placed first in the array.<br /><br />Any attempt to store an object using a different compression algorithm than the ones specified here will fail. |
+| `hash_algorithm`                  | **[HashAlgorithm](#hashalgorithm)**. The algorithm used to hash the content of the objects to generate the id of the objects. The algorithm is optional and if not set, the default algorithm is used.<br /><br />The default algorithm is Sha256 if not set.                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                        |
 
 ### BucketLimits
 
@@ -354,12 +354,12 @@ BucketLimits is the type of the limits of a bucket.
 
 The limits are optional and if not set, there is no limit.
 
-|property|description|
-|----------|-----------|
-|`max_object_pins`|**[Uint128](#uint128)\|null**. The maximum number of pins in the bucket for an object.|
-|`max_object_size`|**[Uint128](#uint128)\|null**. The maximum size of the objects in the bucket.|
-|`max_objects`|**[Uint128](#uint128)\|null**. The maximum number of objects in the bucket.|
-|`max_total_size`|**[Uint128](#uint128)\|null**. The maximum total size of the objects in the bucket.|
+| property          | description                                                                            |
+| ----------------- | -------------------------------------------------------------------------------------- |
+| `max_object_pins` | **[Uint128](#uint128)\|null**. The maximum number of pins in the bucket for an object. |
+| `max_object_size` | **[Uint128](#uint128)\|null**. The maximum size of the objects in the bucket.          |
+| `max_objects`     | **[Uint128](#uint128)\|null**. The maximum number of objects in the bucket.            |
+| `max_total_size`  | **[Uint128](#uint128)\|null**. The maximum total size of the objects in the bucket.    |
 
 ### CompressionAlgorithm
 
@@ -367,23 +367,23 @@ CompressionAlgorithm is an enumeration that defines the different compression al
 
 The order of the compression algorithms is based on their estimated computational cost (quite opinionated) during both compression and decompression, ranging from the lowest to the highest. This particular order is utilized to establish the default compression algorithm for storing an object.
 
-|variant|description|
-|-------|-----------|
-|[Passthrough](#passthrough)|**string**: `passthrough`. Represents no compression algorithm. The object is stored as is without any compression.|
-|[Snappy](#snappy)|**string**: `snappy`. Represents the Snappy algorithm. Snappy is a compression/decompression algorithm that does not aim for maximum compression. Instead, it aims for very high speeds and reasonable compression.<br /><br />See [the snappy web page](https://google.github.io/snappy/) for more information.|
-|[Lzma](#lzma)|**string**: `lzma`. Represents the LZMA algorithm. LZMA is a lossless data compression/decompression algorithm that features a high compression ratio and a variable compression-dictionary size up to 4 GB.<br /><br />See [the LZMA wiki page](https://en.wikipedia.org/wiki/Lempel%E2%80%93Ziv%E2%80%93Markov_chain_algorithm) for more information.|
+| variant                     | description                                                                                                                                                                                                                                                                                                                                             |
+| --------------------------- | ------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
+| [Passthrough](#passthrough) | **string**: `passthrough`. Represents no compression algorithm. The object is stored as is without any compression.                                                                                                                                                                                                                                     |
+| [Snappy](#snappy)           | **string**: `snappy`. Represents the Snappy algorithm. Snappy is a compression/decompression algorithm that does not aim for maximum compression. Instead, it aims for very high speeds and reasonable compression.<br /><br />See [the snappy web page](https://google.github.io/snappy/) for more information.                                        |
+| [Lzma](#lzma)               | **string**: `lzma`. Represents the LZMA algorithm. LZMA is a lossless data compression/decompression algorithm that features a high compression ratio and a variable compression-dictionary size up to 4 GB.<br /><br />See [the LZMA wiki page](https://en.wikipedia.org/wiki/Lempel%E2%80%93Ziv%E2%80%93Markov_chain_algorithm) for more information. |
 
 ### HashAlgorithm
 
 HashAlgorithm is an enumeration that defines the different hash algorithms supported for hashing the content of objects.
 
-|variant|description|
-|-------|-----------|
-|[MD5](#md5)|**string**: `m_d5`. Represents the MD5 algorithm. MD5 is a widely used cryptographic hash function that produces a 128-bit hash value. The computational cost of MD5 is relatively low compared to other hash functions, but its short hash length makes it easier to find hash collisions. It is now considered insecure for cryptographic purposes, but can still used in non-security contexts.<br /><br />MD5 hashes are stored on-chain as 32 hexadecimal characters.<br /><br />See [the MD5 Wikipedia page](https://en.wikipedia.org/wiki/MD5) for more information.|
-|[SHA1](#sha1)|**string**: `sha224`. Represents the SHA-224 algorithm. SHA-224 is a variant of the SHA-2 family of hash functions that produces a 224-bit hash value. It is similar to SHA-256, but with a shorter output size. The computational cost of SHA-224 is moderate, and its relatively short hash length makes it easier to store and transmit.<br /><br />SHA-224 hashes are stored on-chain as 56 hexadecimal characters.<br /><br />See [the SHA-2 Wikipedia page](https://en.wikipedia.org/wiki/SHA-2) for more information.|
-|[SHA256](#sha256)|**string**: `sha256`. Represents the SHA-256 algorithm. SHA-256 is a member of the SHA-2 family of hash functions that produces a 256-bit hash value. It is widely used in cryptography and other security-related applications. The computational cost of SHA-256 is moderate, and its hash length strikes a good balance between security and convenience.<br /><br />SHA-256 hashes are stored on-chain as 64 hexadecimal characters.<br /><br />See [the SHA-2 Wikipedia page](https://en.wikipedia.org/wiki/SHA-2) for more information.|
-|[SHA384](#sha384)|**string**: `sha384`. Represents the SHA-384 algorithm. SHA-384 is a variant of the SHA-2 family of hash functions that produces a 384-bit hash value. It is similar to SHA-512, but with a shorter output size. The computational cost of SHA-384 is relatively high, but its longer hash length provides better security against hash collisions.<br /><br />SHA-384 hashes are stored on-chain as 96 hexadecimal characters.<br /><br />See [the SHA-2 Wikipedia page](https://en.wikipedia.org/wiki/SHA-2) for more information.|
-|[SHA512](#sha512)|**string**: `sha512`. Represents the SHA-512 algorithm. SHA-512 is a member of the SHA-2 family of hash functions that produces a 512-bit hash value. It is widely used in cryptography and other security-related applications. The computational cost of SHA-512 is relatively high, but its longer hash length provides better security against hash collisions.<br /><br />SHA-512 hashes are stored on-chain as 128 hexadecimal characters.<br /><br />See [the SHA-2 Wikipedia page](https://en.wikipedia.org/wiki/SHA-2) for more information.|
+| variant           | description                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                 |
+| ----------------- | --------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
+| [MD5](#md5)       | **string**: `m_d5`. Represents the MD5 algorithm. MD5 is a widely used cryptographic hash function that produces a 128-bit hash value. The computational cost of MD5 is relatively low compared to other hash functions, but its short hash length makes it easier to find hash collisions. It is now considered insecure for cryptographic purposes, but can still used in non-security contexts.<br /><br />MD5 hashes are stored on-chain as 32 hexadecimal characters.<br /><br />See [the MD5 Wikipedia page](https://en.wikipedia.org/wiki/MD5) for more information. |
+| [SHA1](#sha1)     | **string**: `sha224`. Represents the SHA-224 algorithm. SHA-224 is a variant of the SHA-2 family of hash functions that produces a 224-bit hash value. It is similar to SHA-256, but with a shorter output size. The computational cost of SHA-224 is moderate, and its relatively short hash length makes it easier to store and transmit.<br /><br />SHA-224 hashes are stored on-chain as 56 hexadecimal characters.<br /><br />See [the SHA-2 Wikipedia page](https://en.wikipedia.org/wiki/SHA-2) for more information.                                                |
+| [SHA256](#sha256) | **string**: `sha256`. Represents the SHA-256 algorithm. SHA-256 is a member of the SHA-2 family of hash functions that produces a 256-bit hash value. It is widely used in cryptography and other security-related applications. The computational cost of SHA-256 is moderate, and its hash length strikes a good balance between security and convenience.<br /><br />SHA-256 hashes are stored on-chain as 64 hexadecimal characters.<br /><br />See [the SHA-2 Wikipedia page](https://en.wikipedia.org/wiki/SHA-2) for more information.                               |
+| [SHA384](#sha384) | **string**: `sha384`. Represents the SHA-384 algorithm. SHA-384 is a variant of the SHA-2 family of hash functions that produces a 384-bit hash value. It is similar to SHA-512, but with a shorter output size. The computational cost of SHA-384 is relatively high, but its longer hash length provides better security against hash collisions.<br /><br />SHA-384 hashes are stored on-chain as 96 hexadecimal characters.<br /><br />See [the SHA-2 Wikipedia page](https://en.wikipedia.org/wiki/SHA-2) for more information.                                        |
+| [SHA512](#sha512) | **string**: `sha512`. Represents the SHA-512 algorithm. SHA-512 is a member of the SHA-2 family of hash functions that produces a 512-bit hash value. It is widely used in cryptography and other security-related applications. The computational cost of SHA-512 is relatively high, but its longer hash length provides better security against hash collisions.<br /><br />SHA-512 hashes are stored on-chain as 128 hexadecimal characters.<br /><br />See [the SHA-2 Wikipedia page](https://en.wikipedia.org/wiki/SHA-2) for more information.                       |
 
 ### Lzma
 
@@ -391,9 +391,9 @@ Represents the LZMA algorithm. LZMA is a lossless data compression/decompression
 
 See [the LZMA wiki page](https://en.wikipedia.org/wiki/Lempel%E2%80%93Ziv%E2%80%93Markov_chain_algorithm) for more information.
 
-|literal|
-|-------|
-|`"lzma"`|
+| literal  |
+| -------- |
+| `"lzma"` |
 
 ### MD5
 
@@ -403,31 +403,31 @@ MD5 hashes are stored on-chain as 32 hexadecimal characters.
 
 See [the MD5 Wikipedia page](https://en.wikipedia.org/wiki/MD5) for more information.
 
-|literal|
-|-------|
-|`"m_d5"`|
+| literal  |
+| -------- |
+| `"m_d5"` |
 
 ### ObjectResponse
 
 ObjectResponse is the response of the Object query.
 
-|property|description|
-|----------|-----------|
-|`compressed_size`|*(Required.) * **[Uint128](#uint128)**. The size of the object when compressed. If the object is not compressed, the value is the same as `size`.|
-|`compression_algorithm`|*(Required.) * **[CompressionAlgorithm](#compressionalgorithm)**. The compression algorithm used to compress the content of the object.|
-|`id`|*(Required.) * **string**. The id of the object.|
-|`is_pinned`|*(Required.) * **boolean**. Tells if the object is pinned by at least one address.|
-|`owner`|*(Required.) * **string**. The owner of the object.|
-|`size`|*(Required.) * **[Uint128](#uint128)**. The size of the object.|
+| property                | description                                                                                                                                       |
+| ----------------------- | ------------------------------------------------------------------------------------------------------------------------------------------------- |
+| `compressed_size`       | _(Required.) _ **[Uint128](#uint128)**. The size of the object when compressed. If the object is not compressed, the value is the same as `size`. |
+| `compression_algorithm` | _(Required.) _ **[CompressionAlgorithm](#compressionalgorithm)**. The compression algorithm used to compress the content of the object.           |
+| `id`                    | _(Required.) _ **string**. The id of the object.                                                                                                  |
+| `is_pinned`             | _(Required.) _ **boolean**. Tells if the object is pinned by at least one address.                                                                |
+| `owner`                 | _(Required.) _ **string**. The owner of the object.                                                                                               |
+| `size`                  | _(Required.) _ **[Uint128](#uint128)**. The size of the object.                                                                                   |
 
 ### PageInfo
 
 PageInfo is the page information returned for paginated queries.
 
-|property|description|
-|----------|-----------|
-|`cursor`|*(Required.) * **string**. The cursor to the next page.|
-|`has_next_page`|*(Required.) * **boolean**. Tells if there is a next page.|
+| property        | description                                                |
+| --------------- | ---------------------------------------------------------- |
+| `cursor`        | _(Required.) _ **string**. The cursor to the next page.    |
+| `has_next_page` | _(Required.) _ **boolean**. Tells if there is a next page. |
 
 ### PaginationConfig
 
@@ -435,18 +435,18 @@ PaginationConfig is the type carrying configuration for paginated queries.
 
 The fields are optional and if not set, there is a default configuration.
 
-|property|description|
-|----------|-----------|
-|`default_page_size`|**integer**. The default number of elements in a page.<br /><br />Shall be less or equal than `max_page_size`. Default to '10' if not set.|
-|`max_page_size`|**integer**. The maximum elements a page can contain.<br /><br />Shall be less than `u32::MAX - 1`. Default to '30' if not set.|
+| property            | description                                                                                                                                |
+| ------------------- | ------------------------------------------------------------------------------------------------------------------------------------------ |
+| `default_page_size` | **integer**. The default number of elements in a page.<br /><br />Shall be less or equal than `max_page_size`. Default to '10' if not set. |
+| `max_page_size`     | **integer**. The maximum elements a page can contain.<br /><br />Shall be less than `u32::MAX - 1`. Default to '30' if not set.            |
 
 ### Passthrough
 
 Represents no compression algorithm. The object is stored as is without any compression.
 
-|literal|
-|-------|
-|`"passthrough"`|
+| literal         |
+| --------------- |
+| `"passthrough"` |
 
 ### SHA1
 
@@ -456,9 +456,9 @@ SHA-224 hashes are stored on-chain as 56 hexadecimal characters.
 
 See [the SHA-2 Wikipedia page](https://en.wikipedia.org/wiki/SHA-2) for more information.
 
-|literal|
-|-------|
-|`"sha224"`|
+| literal    |
+| ---------- |
+| `"sha224"` |
 
 ### SHA256
 
@@ -468,9 +468,9 @@ SHA-256 hashes are stored on-chain as 64 hexadecimal characters.
 
 See [the SHA-2 Wikipedia page](https://en.wikipedia.org/wiki/SHA-2) for more information.
 
-|literal|
-|-------|
-|`"sha256"`|
+| literal    |
+| ---------- |
+| `"sha256"` |
 
 ### SHA384
 
@@ -480,9 +480,9 @@ SHA-384 hashes are stored on-chain as 96 hexadecimal characters.
 
 See [the SHA-2 Wikipedia page](https://en.wikipedia.org/wiki/SHA-2) for more information.
 
-|literal|
-|-------|
-|`"sha384"`|
+| literal    |
+| ---------- |
+| `"sha384"` |
 
 ### SHA512
 
@@ -492,9 +492,9 @@ SHA-512 hashes are stored on-chain as 128 hexadecimal characters.
 
 See [the SHA-2 Wikipedia page](https://en.wikipedia.org/wiki/SHA-2) for more information.
 
-|literal|
-|-------|
-|`"sha512"`|
+| literal    |
+| ---------- |
+| `"sha512"` |
 
 ### Snappy
 
@@ -502,18 +502,18 @@ Represents the Snappy algorithm. Snappy is a compression/decompression algorithm
 
 See [the snappy web page](https://google.github.io/snappy/) for more information.
 
-|literal|
-|-------|
-|`"snappy"`|
+| literal    |
+| ---------- |
+| `"snappy"` |
 
 ### Uint128
 
 A string containing a 128-bit integer in decimal representation.
 
-|type|
-|----|
-|**string**.|
+| type        |
+| ----------- |
+| **string**. |
 
 ---
 
-*Rendered by [Fadroma](https://fadroma.tech) ([@fadroma/schema 1.1.0](https://www.npmjs.com/package/@fadroma/schema)) from `okp4-objectarium.json` (`51f0131cd7a4ebf9`)*
+_Rendered by [Fadroma](https://fadroma.tech) ([@fadroma/schema 1.1.0](https://www.npmjs.com/package/@fadroma/schema)) from `okp4-objectarium.json` (`51f0131cd7a4ebf9`)_


### PR DESCRIPTION
This PR introduces two steps in the documentation generation process:

- An escaping step for the `{` and `}` characters, which are incompatible with the[ MDX v3 format](https://docusaurus.io/blog/preparing-your-site-for-docusaurus-v3#preparing-content-for-mdx-v3) used by our [Docusaurus-based documentation site](https://github.com/okp4/docs).
- A content normalization step utilizing [Prettier](https://prettier.io/).

_NB: For ease of implementation, I've used a bit of [Perl](https://www.perl.org/) magic to handle the escaping.  I apologize for any inconvenience this may cause._

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Documentation**
  - Improved the formatting and alignment of tables and descriptions across various documentation files for better readability.
  - Restructured and cleaned up documentation to remove redundancy and enhance clarity.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->