### PR TITLE
Feat/dataverse proof di

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -472,9 +472,9 @@ checksum = "4f94fa09c2aeea5b8839e414b7b841bf429fd25b9c522116ac97ee87856d88b2"
 
 [[package]]
 name = "ecdsa"
-version = "0.16.8"
+version = "0.16.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a4b1e0c257a9e9f25f90ff76d7a68360ed497ee519c8e428d1825ef0000799d4"
+checksum = "ee27f32b5c5292967d2d4a9d7f1e0b0aed2c15daded5a60300e4abb9d8020bca"
 dependencies = [
  "der",
  "digest 0.10.7",
@@ -483,12 +483,6 @@ dependencies = [
  "signature",
  "spki",
 ]
-
-[[package]]
-name = "ed25519-compact"
-version = "2.0.6"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a667e6426df16c2ac478efa4a439d0e674cba769c5556e8cf221739251640c8c"
 
 [[package]]
 name = "ed25519-zebra"
@@ -513,9 +507,9 @@ checksum = "a26ae43d7bcc3b814de94796a5e736d4029efb0ee900c12e2d54c993ad1a1e07"
 
 [[package]]
 name = "elliptic-curve"
-version = "0.13.5"
+version = "0.13.8"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "968405c8fdc9b3bf4df0a6638858cc0b52462836ab6b1c87377785dd09cf1c0b"
+checksum = "b5e6043086bf7973472e0c7dff2142ea0b680d30e18d9cc40f267efbf222bd47"
 dependencies = [
  "base16ct",
  "crypto-bigint",
@@ -782,7 +776,6 @@ dependencies = [
  "cw-storage-plus",
  "cw-utils",
  "cw2",
- "ed25519-compact",
  "itertools 0.12.1",
  "multibase",
  "okp4-cognitarium",
@@ -1327,6 +1320,6 @@ checksum = "9c8d87e72b64a3b4db28d11ce29237c246188f4f51057d65a7eab63b7987e423"
 
 [[package]]
 name = "zeroize"
-version = "1.5.7"
+version = "1.7.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c394b5bd0c6f669e7275d9c20aa90ae064cb22e75a1cad54e1b34088034b149f"
+checksum = "525b4ec142c6b68a2d10f01f7bbf6755599ca3f81ea53b8431b7dd348f5fdb2d"

--- a/contracts/okp4-dataverse/Cargo.toml
+++ b/contracts/okp4-dataverse/Cargo.toml
@@ -35,9 +35,6 @@ cosmwasm-storage.workspace = true
 cw-storage-plus.workspace = true
 cw-utils.workspace = true
 cw2.workspace = true
-ed25519-compact = { version = "2.0.6", default-features = false, features = [
-  "std",
-] }
 itertools = "0.12.1"
 multibase = "0.9.1"
 okp4-cognitarium.workspace = true

--- a/contracts/okp4-dataverse/src/contract.rs
+++ b/contracts/okp4-dataverse/src/contract.rs
@@ -65,7 +65,7 @@ pub fn instantiate(
 
 #[cfg_attr(not(feature = "library"), entry_point)]
 pub fn execute(
-    _deps: DepsMut<'_>,
+    deps: DepsMut<'_>,
     _env: Env,
     _info: MessageInfo,
     msg: ExecuteMsg,
@@ -74,7 +74,7 @@ pub fn execute(
         ExecuteMsg::SubmitClaims {
             metadata,
             format: _,
-        } => execute::submit_claims(metadata),
+        } => execute::submit_claims(deps, metadata),
         _ => Err(StdError::generic_err("Not implemented").into()),
     }
 }
@@ -86,13 +86,13 @@ pub mod execute {
     use okp4_rdf::serde::NQuadsReader;
     use std::io::BufReader;
 
-    pub fn submit_claims(data: Binary) -> Result<Response, ContractError> {
+    pub fn submit_claims(deps: DepsMut<'_>, data: Binary) -> Result<Response, ContractError> {
         let buf = BufReader::new(data.as_slice());
         let mut reader = NQuadsReader::new(buf);
         let rdf_quads = reader.read_all()?;
         let vc_dataset = Dataset::from(rdf_quads.as_slice());
         let vc = VerifiableCredential::try_from(&vc_dataset)?;
-        vc.verify()?;
+        vc.verify(deps)?;
 
         Ok(Response::default())
     }

--- a/contracts/okp4-dataverse/src/credential/error.rs
+++ b/contracts/okp4-dataverse/src/credential/error.rs
@@ -39,6 +39,9 @@ pub enum InvalidProofError {
     #[error("Missing proof value")]
     MissingProofValue,
 
+    #[error("Missing proof cryptosuite")]
+    MissingProofCryptosuite,
+
     #[error("Malformed proof value: {0}")]
     MalformedProofValue(#[from] multibase::Error),
 
@@ -59,7 +62,10 @@ pub enum VerificationError {
     RdfCanonError(#[from] NormalizationError),
 
     #[error("Couldn't verify signature: {0}")]
-    SignatureError(#[from] ed25519_compact::Error),
+    SignatureError(#[from] cosmwasm_std::VerificationError),
+
+    #[error("Signature mismatch")]
+    WrongSignature,
 
     #[error("Couldn't find a suitable proof")]
     NoSuitableProof,

--- a/contracts/okp4-dataverse/src/credential/vc.rs
+++ b/contracts/okp4-dataverse/src/credential/vc.rs
@@ -298,6 +298,7 @@ impl<'a> VerifiableCredential<'a> {
 mod test {
     use super::*;
     use crate::testutil::testutil;
+    use cosmwasm_std::testing::mock_dependencies;
 
     #[test]
     fn proper_vc_from_dataset() {
@@ -335,10 +336,11 @@ mod test {
 
     #[test]
     fn vc_verify() {
+        let mut deps = mock_dependencies();
         let owned_quads = testutil::read_test_quads("vc-ok.nq");
         let dataset = Dataset::from(owned_quads.as_slice());
         let vc = VerifiableCredential::try_from(&dataset).unwrap();
-        let verif_res = vc.verify();
+        let verif_res = vc.verify(deps.as_mut());
         assert!(verif_res.is_ok());
     }
 }

--- a/contracts/okp4-dataverse/src/credential/vc.rs
+++ b/contracts/okp4-dataverse/src/credential/vc.rs
@@ -1,6 +1,7 @@
 use crate::credential::error::{InvalidCredentialError, InvalidProofError, VerificationError};
 use crate::credential::proof::{Proof, ProofPurpose};
 use crate::credential::rdf_marker::*;
+use cosmwasm_std::DepsMut;
 use itertools::Itertools;
 use okp4_rdf::dataset::QuadIterator;
 use okp4_rdf::dataset::{Dataset, QuadPattern};
@@ -73,7 +74,7 @@ impl<'a> TryFrom<&'a Dataset<'a>> for VerifiableCredential<'a> {
 }
 
 impl<'a> VerifiableCredential<'a> {
-    pub fn verify(&self) -> Result<(), VerificationError> {
+    pub fn verify(&self, deps: DepsMut<'_>) -> Result<(), VerificationError> {
         let proof = self
             .proof
             .iter()
@@ -82,6 +83,7 @@ impl<'a> VerifiableCredential<'a> {
 
         let crypto_suite = proof.crypto_suite();
         crypto_suite.verify_document(
+            deps,
             self.unsecured_document.as_ref(),
             proof.options(),
             proof.signature(),

--- a/docs/okp4-cognitarium.md
+++ b/docs/okp4-cognitarium.md
@@ -846,4 +846,4 @@ Represents a condition in a [WhereClause].
 
 ---
 
-_Rendered by [Fadroma](https://fadroma.tech) ([@fadroma/schema 1.1.0](https://www.npmjs.com/package/@fadroma/schema)) from `okp4-cognitarium.json` (`7f3c5c68a89047dc`)_
+_Rendered by [Fadroma](https://fadroma.tech) ([@fadroma/schema 1.1.0](https://www.npmjs.com/package/@fadroma/schema)) from `okp4-cognitarium.json` (`b3bea598ea8fda42`)_

--- a/docs/okp4-law-stone.md
+++ b/docs/okp4-law-stone.md
@@ -134,4 +134,4 @@ A string containing Base64-encoded data.
 
 ---
 
-_Rendered by [Fadroma](https://fadroma.tech) ([@fadroma/schema 1.1.0](https://www.npmjs.com/package/@fadroma/schema)) from `okp4-law-stone.json` (`092608edf6c36d25`)_
+_Rendered by [Fadroma](https://fadroma.tech) ([@fadroma/schema 1.1.0](https://www.npmjs.com/package/@fadroma/schema)) from `okp4-law-stone.json` (`175af2aa8dc69420`)_

--- a/docs/okp4-objectarium.md
+++ b/docs/okp4-objectarium.md
@@ -516,4 +516,4 @@ A string containing a 128-bit integer in decimal representation.
 
 ---
 
-_Rendered by [Fadroma](https://fadroma.tech) ([@fadroma/schema 1.1.0](https://www.npmjs.com/package/@fadroma/schema)) from `okp4-objectarium.json` (`e486ab17656d0e03`)_
+_Rendered by [Fadroma](https://fadroma.tech) ([@fadroma/schema 1.1.0](https://www.npmjs.com/package/@fadroma/schema)) from `okp4-objectarium.json` (`2b01e2531b94fc0e`)_


### PR DESCRIPTION
Add the support of [DataIntegrityProof](https://www.w3.org/TR/vc-data-integrity) in verifiable credentials.

The supported underlying crypto suites are limited to the RDF Canonicalization based ones:
- [eddsa-rdfc-2022](https://www.w3.org/TR/vc-di-eddsa/#eddsa-rdfc-2022)
- [ecdsa-rdfc-2019](https://www.w3.org/TR/vc-di-ecdsa/#ecdsa-rdfc-2019)