### PR TITLE
Feat/dataverse claims storage

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -779,6 +779,7 @@ dependencies = [
  "itertools 0.12.1",
  "multibase",
  "okp4-cognitarium",
+ "okp4-cognitarium-client",
  "okp4-rdf",
  "rio_api",
  "rio_turtle",

--- a/contracts/okp4-dataverse/Cargo.toml
+++ b/contracts/okp4-dataverse/Cargo.toml
@@ -38,6 +38,7 @@ cw-utils.workspace = true
 cw2.workspace = true
 itertools = "0.12.1"
 multibase = "0.9.1"
+okp4-cognitarium-client.workspace = true
 okp4-cognitarium.workspace = true
 okp4-rdf.workspace = true
 rio_api.workspace = true

--- a/contracts/okp4-dataverse/src/contract.rs
+++ b/contracts/okp4-dataverse/src/contract.rs
@@ -276,7 +276,7 @@ mod tests {
             ]
         );
 
-        let expected_data = "<http://example.edu/credentials/3732> <dataverse:credential#submitterAddress> <okp41072nc6egexqr2v6vpp7yxwm68plvqnkf6xsytf> .
+        let expected_data = "<http://example.edu/credentials/3732> <dataverse:credential#submitterAddress> \"okp41072nc6egexqr2v6vpp7yxwm68plvqnkf6xsytf\" .
 <http://example.edu/credentials/3732> <dataverse:credential#issuer> <did:key:z6MkpwdnLPAm4apwcrRYQ6fZ3rAcqjLZR4AMk14vimfnozqY> .
 <http://example.edu/credentials/3732> <dataverse:credential#type> <https://example.org/examples#UniversityDegreeCredential> .
 <http://example.edu/credentials/3732> <dataverse:credential#validFrom> \"2024-02-16T00:00:00Z\"^^<http://www.w3.org/2001/XMLSchema#dateTime> .

--- a/contracts/okp4-dataverse/src/credential/crypto.rs
+++ b/contracts/okp4-dataverse/src/credential/crypto.rs
@@ -39,7 +39,7 @@ impl From<(CanonicalizationAlg, DigestAlg, SignatureAlg)> for CryptoSuite {
 impl CryptoSuite {
     pub fn verify_document(
         &self,
-        deps: DepsMut<'_>,
+        deps: &'_ DepsMut<'_>,
         unsecured_doc: &[Quad<'_>],
         proof_opts: &[Quad<'_>],
         proof_value: &[u8],
@@ -77,7 +77,7 @@ impl CryptoSuite {
 
     fn verify(
         &self,
-        deps: DepsMut<'_>,
+        deps: &'_ DepsMut<'_>,
         message: &[u8],
         signature: &[u8],
         pub_key: &[u8],

--- a/contracts/okp4-dataverse/src/credential/error.rs
+++ b/contracts/okp4-dataverse/src/credential/error.rs
@@ -12,9 +12,6 @@ pub enum InvalidCredentialError {
     #[error("Missing issuance date")]
     MissingIssuanceDate,
 
-    #[error("Missing proof, at least a supported one")]
-    MissingProof,
-
     #[error("Invalid proof: {0}")]
     InvalidProof(#[from] InvalidProofError),
 

--- a/contracts/okp4-dataverse/src/credential/mod.rs
+++ b/contracts/okp4-dataverse/src/credential/mod.rs
@@ -1,5 +1,5 @@
 mod crypto;
 pub mod error;
 mod proof;
-mod rdf_marker;
+pub mod rdf_marker;
 pub mod vc;

--- a/contracts/okp4-dataverse/src/credential/rdf_marker.rs
+++ b/contracts/okp4-dataverse/src/credential/rdf_marker.rs
@@ -10,9 +10,8 @@ pub const RDF_DATE_TYPE: NamedNode<'_> = NamedNode {
     iri: "http://www.w3.org/2001/XMLSchema#dateTime",
 };
 
-pub const VC_RDF_TYPE: Term<'_> = Term::NamedNode(NamedNode {
-    iri: "https://www.w3.org/2018/credentials#VerifiableCredential",
-});
+pub const IRI_VC_TYPE: &str = "https://www.w3.org/2018/credentials#VerifiableCredential";
+pub const VC_RDF_TYPE: Term<'_> = Term::NamedNode(NamedNode { iri: IRI_VC_TYPE });
 pub const VC_RDF_ISSUER: NamedNode<'_> = NamedNode {
     iri: "https://www.w3.org/2018/credentials#issuer",
 };

--- a/contracts/okp4-dataverse/src/credential/vc.rs
+++ b/contracts/okp4-dataverse/src/credential/vc.rs
@@ -217,12 +217,7 @@ impl<'a> VerifiableCredential<'a> {
             })
             .map_ok(|claim_id| Claim {
                 id: claim_id.iri,
-                content: Dataset::new(
-                    dataset
-                        .match_pattern(Some(claim_id.into()), None, None, None)
-                        .copied()
-                        .collect(),
-                ),
+                content: dataset.sub_graph(claim_id.into()),
             })
             .collect()
     }

--- a/contracts/okp4-dataverse/src/credential/vc.rs
+++ b/contracts/okp4-dataverse/src/credential/vc.rs
@@ -42,10 +42,6 @@ impl<'a> TryFrom<&'a Dataset<'a>> for VerifiableCredential<'a> {
         let (proofs, proof_graphs): (Vec<Proof<'a>>, Vec<BlankNode<'a>>) =
             Self::extract_proofs(dataset, id)?.into_iter().unzip();
 
-        if proofs.is_empty() {
-            return Err(InvalidCredentialError::MissingProof);
-        }
-
         let mut unsecured_filter: Vec<QuadPattern<'_>> = proof_graphs
             .into_iter()
             .map(|g| (None, None, None, Some(Some(g.into()))).into())

--- a/contracts/okp4-dataverse/src/credential/vc.rs
+++ b/contracts/okp4-dataverse/src/credential/vc.rs
@@ -9,21 +9,21 @@ use rio_api::model::{BlankNode, Literal, NamedNode, Subject, Term};
 
 #[derive(Debug, PartialEq)]
 pub struct VerifiableCredential<'a> {
-    id: &'a str,
-    types: Vec<&'a str>,
-    issuer: &'a str,
-    issuance_date: &'a str,
-    expiration_date: Option<&'a str>,
-    claims: Vec<Claim<'a>>,
-    status: Option<Status<'a>>,
-    proof: Vec<Proof<'a>>,
+    pub id: &'a str,
+    pub types: Vec<&'a str>,
+    pub issuer: &'a str,
+    pub issuance_date: &'a str,
+    pub expiration_date: Option<&'a str>,
+    pub claims: Vec<Claim<'a>>,
+    pub status: Option<Status<'a>>,
+    pub proof: Vec<Proof<'a>>,
     unsecured_document: Dataset<'a>,
 }
 
 #[derive(Debug, PartialEq)]
 pub struct Claim<'a> {
-    id: &'a str,
-    content: Dataset<'a>,
+    pub id: &'a str,
+    pub content: Dataset<'a>,
 }
 
 #[derive(Debug, PartialEq)]
@@ -74,7 +74,7 @@ impl<'a> TryFrom<&'a Dataset<'a>> for VerifiableCredential<'a> {
 }
 
 impl<'a> VerifiableCredential<'a> {
-    pub fn verify(&self, deps: DepsMut<'_>) -> Result<(), VerificationError> {
+    pub fn verify(&self, deps: &'_ DepsMut<'_>) -> Result<(), VerificationError> {
         let proof = self
             .proof
             .iter()
@@ -347,7 +347,7 @@ mod test {
             let owned_quads = testutil::read_test_quads(case);
             let dataset = Dataset::from(owned_quads.as_slice());
             let vc = VerifiableCredential::try_from(&dataset).unwrap();
-            let verif_res = vc.verify(deps.as_mut());
+            let verif_res = vc.verify(&deps.as_mut());
             assert!(verif_res.is_ok());
         }
     }

--- a/contracts/okp4-dataverse/src/credential/vc.rs
+++ b/contracts/okp4-dataverse/src/credential/vc.rs
@@ -95,10 +95,10 @@ impl<'a> VerifiableCredential<'a> {
             .subjects()
             .exactly_one()
             .map_err(|e| match e.size_hint() {
-                (_, Some(_)) => InvalidCredentialError::MissingIdentifier,
-                _ => InvalidCredentialError::Malformed(
+                (_, Some(_)) => InvalidCredentialError::Malformed(
                     "Credential cannot have more than one id".to_string(),
                 ),
+                _ => InvalidCredentialError::MissingIdentifier,
             })
             .and_then(|s| match s {
                 Subject::NamedNode(n) => Ok(n),

--- a/contracts/okp4-dataverse/src/credential/vc.rs
+++ b/contracts/okp4-dataverse/src/credential/vc.rs
@@ -294,6 +294,7 @@ mod test {
     use super::*;
     use crate::testutil::testutil;
     use cosmwasm_std::testing::mock_dependencies;
+    use rio_api::model::Quad;
 
     #[test]
     fn proper_vc_from_dataset() {
@@ -306,22 +307,62 @@ mod test {
         let vc_res = VerifiableCredential::try_from(&dataset);
         assert!(vc_res.is_ok());
         let vc = vc_res.unwrap();
-        assert_eq!(vc.id, "http://example.edu/credentials/58473");
+        assert_eq!(vc.id, "http://example.edu/credentials/3732");
         assert_eq!(
             vc.types,
-            vec!["https://www.w3.org/2018/credentials#VerifiableCredential"]
+            vec![
+                "https://example.org/examples#UniversityDegreeCredential",
+                "https://www.w3.org/2018/credentials#VerifiableCredential"
+            ]
         );
         assert_eq!(
             vc.issuer,
             "did:key:z6MkpwdnLPAm4apwcrRYQ6fZ3rAcqjLZR4AMk14vimfnozqY"
         );
-        assert_eq!(vc.issuance_date, "2023-05-01T06:09:10Z");
-        assert_eq!(vc.expiration_date, None);
+        assert_eq!(vc.issuance_date, "2024-02-16T00:00:00Z");
+        assert_eq!(vc.expiration_date, Some("2026-02-16T00:00:00Z"));
         assert_eq!(
             vc.claims,
             vec![Claim {
-                id: "did:key:z6MkpwdnLPAm4apwcrRYQ6fZ3rAcqjLZR4AMk14vimfnozqY",
-                content: Dataset::new(vec![]),
+                id: "did:key:zDnaeUm3QkcyZWZTPttxB711jgqRDhkwvhF485SFw1bDZ9AQw",
+                content: Dataset::new(vec![
+                    Quad {
+                        subject: NamedNode {
+                            iri: "did:key:zDnaeUm3QkcyZWZTPttxB711jgqRDhkwvhF485SFw1bDZ9AQw"
+                        }
+                        .into(),
+                        predicate: NamedNode {
+                            iri: "https://example.org/examples#degree"
+                        },
+                        object: BlankNode { id: "b2" }.into(),
+                        graph_name: None
+                    },
+                    Quad {
+                        subject: BlankNode { id: "b2" }.into(),
+                        predicate: NamedNode {
+                            iri: "http://schema.org/name"
+                        },
+                        object: Literal::Typed {
+                            value: "Bachelor of Science and Arts",
+                            datatype: NamedNode {
+                                iri: "http://www.w3.org/1999/02/22-rdf-syntax-ns#HTML"
+                            }
+                        }
+                        .into(),
+                        graph_name: None
+                    },
+                    Quad {
+                        subject: BlankNode { id: "b2" }.into(),
+                        predicate: NamedNode {
+                            iri: "http://www.w3.org/1999/02/22-rdf-syntax-ns#type"
+                        },
+                        object: NamedNode {
+                            iri: "https://example.org/examples#BachelorDegree"
+                        }
+                        .into(),
+                        graph_name: None
+                    }
+                ])
             }]
         );
         assert_eq!(vc.status, None);

--- a/contracts/okp4-dataverse/src/error.rs
+++ b/contracts/okp4-dataverse/src/error.rs
@@ -17,6 +17,12 @@ pub enum ContractError {
     #[error("Invalid credential: '{0}'")]
     InvalidCredential(#[from] InvalidCredentialError),
 
-    #[error("Credential verification failed: {0}")]
+    #[error("Credential verification failed: '{0}'")]
     CredentialVerification(#[from] VerificationError),
+
+    #[error("Credential not supported: '{0}'")]
+    UnsupportedCredential(String),
+
+    #[error("Credential already exists: '{0}'")]
+    CredentialAlreadyExists(String),
 }

--- a/contracts/okp4-dataverse/src/lib.rs
+++ b/contracts/okp4-dataverse/src/lib.rs
@@ -14,6 +14,7 @@ pub mod contract;
 mod credential;
 mod error;
 pub mod msg;
+mod registrar;
 pub mod state;
 mod testutil;
 

--- a/contracts/okp4-dataverse/src/msg.rs
+++ b/contracts/okp4-dataverse/src/msg.rs
@@ -26,11 +26,7 @@ pub enum ExecuteMsg {
     ///
     /// #### Format
     ///
-    /// Claims are injected into the dataverse through Verifiable Presentations (VPs). These presentations effectively amalgamate and
-    /// showcase multiple credentials, thus providing a cohesive and comprehensive view of the assertions being made.
-    ///
-    /// While the data in a VP typically revolves around a common subject, it accommodates an unlimited number of subjects and issuers.
-    /// This flexibility allows for a broad spectrum of claims to be represented.
+    /// Claims are injected into the dataverse through Verifiable Credentials (VCs).
     ///
     /// Primarily, the claims leverage the OKP4 ontology, which facilitates articulating assertions about widely acknowledged resources
     /// in the dataverse, including digital services, digital resources, zones, governance, and more.
@@ -41,11 +37,22 @@ pub enum ExecuteMsg {
     ///
     /// To maintain integrity and coherence in the dataverse, several preconditions are set for the submission of claims:
     ///
-    ///   1. **Format Requirement**: Claims must be encapsulated within Verifiable Presentations (VPs).
+    ///   1. **Format Requirement**: Claims must be encapsulated within Verifiable Credentials (VCs).
     ///
     ///   2. **Unique Identifier Mandate**: Each Verifiable Credential within the dataverse must possess a unique identifier.
     ///
     ///   3. **Issuer Signature**: Claims must bear the issuer's signature. This signature must be verifiable, ensuring authenticity and credibility.
+    ///
+    ///   4. **Content**: The actual implementation supports the submission of a single Verifiable Credential, containing a single claim.
+    ///
+    /// #### Supported cryptographic proofs
+    ///
+    /// - `Ed25519Signature2020`
+    ///
+    /// - `EcdsaSecp256k1Signature2019`
+    ///
+    /// - `DataIntegrity` with the following cryptosuites: `eddsa-2022`, `eddsa-rdfc-2022`.
+    ///
     SubmitClaims {
         /// The serialized metadata intended for attachment.
         /// This metadata should adhere to the format specified in the `format` field.

--- a/contracts/okp4-dataverse/src/registrar/credential.rs
+++ b/contracts/okp4-dataverse/src/registrar/credential.rs
@@ -1,9 +1,10 @@
 use crate::credential::rdf_marker::IRI_VC_TYPE;
 use crate::credential::vc::VerifiableCredential;
+use crate::registrar::rdf::VC_CLAIM;
 use crate::ContractError;
 use cosmwasm_std::Addr;
 use itertools::Itertools;
-use okp4_rdf::dataset::Dataset;
+use rio_api::model::{BlankNode, NamedNode, Subject, Term, Triple};
 
 #[derive(Debug, PartialEq)]
 pub struct DataverseCredential<'a> {
@@ -14,7 +15,7 @@ pub struct DataverseCredential<'a> {
     pub valid_from: &'a str,
     pub valid_until: Option<&'a str>,
     pub subject: &'a str,
-    pub claim: &'a Dataset<'a>,
+    pub claim: Vec<Triple<'a>>,
 }
 
 impl<'a> DataverseCredential<'a> {
@@ -33,16 +34,46 @@ impl<'a> DataverseCredential<'a> {
 
     fn extract_vc_claim(
         vc: &'a VerifiableCredential<'a>,
-    ) -> Result<(&'a str, &'a Dataset<'a>), ContractError> {
-        vc.claims
+    ) -> Result<(&'a str, Vec<Triple<'a>>), ContractError> {
+        //todo: use the canon identifier issuer instead and rename all blank nodes
+        let claim_node = BlankNode { id: "c0" };
+
+        let claim = vc.claims.iter().exactly_one().map_err(|_| {
+            ContractError::UnsupportedCredential(
+                "credential is expected to contain exactly one claim".to_string(),
+            )
+        })?;
+
+        let mut triples = claim
+            .content
             .iter()
-            .exactly_one()
-            .map(|claim| (claim.id, &(claim.content)))
-            .map_err(|_| {
-                ContractError::UnsupportedCredential(
-                    "credential is expected to contain exactly one claim".to_string(),
-                )
+            .map(|q| {
+                let subject = match q.subject {
+                    Subject::NamedNode(n) => {
+                        if n.iri != claim.id {
+                            Err(ContractError::UnsupportedCredential(
+                                "claim hierarchy can be forge only through blank nodes".to_string(),
+                            ))?;
+                        }
+                        Subject::BlankNode(claim_node)
+                    }
+                    _ => q.subject,
+                };
+                Ok(Triple {
+                    subject,
+                    predicate: q.predicate,
+                    object: q.object,
+                })
             })
+            .collect::<Result<Vec<Triple<'a>>, ContractError>>()?;
+
+        triples.push(Triple {
+            subject: Subject::NamedNode(NamedNode { iri: vc.id }),
+            predicate: VC_CLAIM,
+            object: Term::BlankNode(BlankNode { id: "c0" }),
+        });
+
+        Ok((claim.id, triples))
     }
 }
 

--- a/contracts/okp4-dataverse/src/registrar/credential.rs
+++ b/contracts/okp4-dataverse/src/registrar/credential.rs
@@ -96,3 +96,85 @@ impl<'a> TryFrom<(Addr, &'a VerifiableCredential<'a>)> for DataverseCredential<'
         })
     }
 }
+
+#[cfg(test)]
+mod test {
+    use super::*;
+    use crate::testutil::testutil;
+    use okp4_rdf::dataset::Dataset;
+    use rio_api::model::Literal;
+
+    #[test]
+    fn proper_from_verifiable() {
+        let owned_quads = testutil::read_test_quads("vc-valid.nq");
+        let dataset = Dataset::from(owned_quads.as_slice());
+        let vc = VerifiableCredential::try_from(&dataset).unwrap();
+        let dc_res = DataverseCredential::try_from((
+            Addr::unchecked("okp41072nc6egexqr2v6vpp7yxwm68plvqnkf6xsytf"),
+            &vc,
+        ));
+
+        assert!(dc_res.is_ok());
+        assert_eq!(dc_res.unwrap(), DataverseCredential {
+                submitter_addr: Addr::unchecked("okp41072nc6egexqr2v6vpp7yxwm68plvqnkf6xsytf"),
+                id: "https://w3id.org/okp4/ontology/vnext/schema/credential/digital-service/description/72cab400-5bd6-4eb4-8605-a5ee8c1a45c9",
+                issuer: "did:key:zQ3shs7auhJSmVJpiUbQWco6bxxEhSqWnVEPvaBHBRvBKw6Q3",
+                r#type: "https://w3id.org/okp4/ontology/vnext/schema/credential/digital-service/description/DigitalServiceDescriptionCredential",
+                valid_from: "2024-01-22T00:00:00",
+                valid_until: Some("2025-01-22T00:00:00"),
+                subject: "did:key:zQ3shhb4SvzBRLbBonsvKb3WX6WoDeKWHpsXXXMhAJETqXAfB",
+                claim: vec![Triple {
+                    subject: BlankNode {id: "c0"}.into(),
+                    predicate: NamedNode {iri: "https://w3id.org/okp4/ontology/vnext/schema/credential/digital-service/description/hasCategory"},
+                    object: NamedNode {iri: "https://w3id.org/okp4/ontology/vnext/thesaurus/digital-service-category/Storage"}.into(),
+                },Triple {
+                    subject: BlankNode {id: "c0"}.into(),
+                    predicate: NamedNode {iri: "https://w3id.org/okp4/ontology/vnext/schema/credential/digital-service/description/hasTag"},
+                    object: Literal::Simple {value: "Cloud"}.into(),
+                },Triple {
+                    subject: NamedNode {iri: "https://w3id.org/okp4/ontology/vnext/schema/credential/digital-service/description/72cab400-5bd6-4eb4-8605-a5ee8c1a45c9"}.into(),
+                    predicate: NamedNode {iri: "dataverse:credential#claim"},
+                    object: BlankNode {id: "c0"}.into(),
+                }],
+            })
+    }
+
+    #[test]
+    fn unsupported_from_verifiable() {
+        let cases = vec![
+            (
+                "vc-unsupported-1.nq",
+                "credential is expected to have exactly one type",
+            ),
+            (
+                "vc-unsupported-2.nq",
+                "credential is expected to have exactly one type",
+            ),
+            (
+                "vc-unsupported-3.nq",
+                "credential is expected to contain exactly one claim",
+            ),
+            (
+                "vc-unsupported-4.nq",
+                "claim hierarchy can be forge only through blank nodes",
+            ),
+        ];
+
+        for case in cases {
+            let owned_quads = testutil::read_test_quads(case.0);
+            let dataset = Dataset::from(owned_quads.as_slice());
+            let vc = VerifiableCredential::try_from(&dataset).unwrap();
+            let dc_res = DataverseCredential::try_from((
+                Addr::unchecked("okp41072nc6egexqr2v6vpp7yxwm68plvqnkf6xsytf"),
+                &vc,
+            ));
+
+            assert!(dc_res.is_err());
+            if let ContractError::UnsupportedCredential(msg) = dc_res.err().unwrap() {
+                assert_eq!(msg, case.1.to_string());
+            } else {
+                assert!(false);
+            }
+        }
+    }
+}

--- a/contracts/okp4-dataverse/src/registrar/credential.rs
+++ b/contracts/okp4-dataverse/src/registrar/credential.rs
@@ -1,0 +1,67 @@
+use crate::credential::rdf_marker::IRI_VC_TYPE;
+use crate::credential::vc::VerifiableCredential;
+use crate::ContractError;
+use cosmwasm_std::Addr;
+use itertools::Itertools;
+use okp4_rdf::dataset::Dataset;
+
+#[derive(Debug, PartialEq)]
+pub struct DataverseCredential<'a> {
+    pub submitter_addr: Addr,
+    pub id: &'a str,
+    pub issuer: &'a str,
+    pub r#type: &'a str,
+    pub valid_from: &'a str,
+    pub valid_until: Option<&'a str>,
+    pub subject: &'a str,
+    pub claim: &'a Dataset<'a>,
+}
+
+impl<'a> DataverseCredential<'a> {
+    fn extract_vc_type(vc: &'a VerifiableCredential<'a>) -> Result<&'a str, ContractError> {
+        vc.types
+            .iter()
+            .filter(|t| *t != &IRI_VC_TYPE)
+            .exactly_one()
+            .map_err(|_| {
+                ContractError::UnsupportedCredential(
+                    "credential is expected to have exactly one type".to_string(),
+                )
+            })
+            .map(|t| *t)
+    }
+
+    fn extract_vc_claim(
+        vc: &'a VerifiableCredential<'a>,
+    ) -> Result<(&'a str, &'a Dataset<'a>), ContractError> {
+        vc.claims
+            .iter()
+            .exactly_one()
+            .map(|claim| (claim.id, &(claim.content)))
+            .map_err(|_| {
+                ContractError::UnsupportedCredential(
+                    "credential is expected to contain exactly one claim".to_string(),
+                )
+            })
+    }
+}
+
+impl<'a> TryFrom<(Addr, &'a VerifiableCredential<'a>)> for DataverseCredential<'a> {
+    type Error = ContractError;
+
+    fn try_from(
+        (submitter_addr, vc): (Addr, &'a VerifiableCredential<'a>),
+    ) -> Result<Self, Self::Error> {
+        let (subject, claim) = DataverseCredential::extract_vc_claim(vc)?;
+        Ok(DataverseCredential {
+            submitter_addr,
+            id: vc.id,
+            issuer: vc.issuer,
+            r#type: DataverseCredential::extract_vc_type(vc)?,
+            valid_from: vc.issuance_date,
+            valid_until: vc.expiration_date,
+            subject,
+            claim,
+        })
+    }
+}

--- a/contracts/okp4-dataverse/src/registrar/mod.rs
+++ b/contracts/okp4-dataverse/src/registrar/mod.rs
@@ -1,0 +1,3 @@
+pub mod credential;
+mod rdf;
+pub mod registry;

--- a/contracts/okp4-dataverse/src/registrar/rdf.rs
+++ b/contracts/okp4-dataverse/src/registrar/rdf.rs
@@ -1,4 +1,4 @@
-use crate::credential::rdf_marker::{RDF_DATE_TYPE, RDF_TYPE};
+use crate::credential::rdf_marker::RDF_DATE_TYPE;
 use crate::registrar::credential::DataverseCredential;
 use crate::ContractError;
 use cosmwasm_std::{Binary, StdError};
@@ -7,6 +7,9 @@ use rio_api::model::{BlankNode, Literal, NamedNode, Subject, Term, Triple};
 
 pub const VC_SUBMITTER_ADDRESS: NamedNode<'_> = NamedNode {
     iri: "dataverse:credential#submitterAddress",
+};
+pub const VC_TYPE: NamedNode<'_> = NamedNode {
+    iri: "dataverse:credential#type",
 };
 pub const VC_ISSUER: NamedNode<'_> = NamedNode {
     iri: "dataverse:credential#issuer",
@@ -29,6 +32,7 @@ impl<'a> TryFrom<&'a DataverseCredential<'a>> for Vec<Triple<'a>> {
 
     fn try_from(credential: &'a DataverseCredential<'a>) -> Result<Self, Self::Error> {
         let c_subject = Subject::NamedNode(NamedNode { iri: credential.id });
+        //todo: use the canon identifier issuer instead and rename all blank nodes
         let claim_node = BlankNode { id: "c0" };
 
         let mut triples = vec![
@@ -48,17 +52,17 @@ impl<'a> TryFrom<&'a DataverseCredential<'a>> for Vec<Triple<'a>> {
             },
             Triple {
                 subject: c_subject,
-                predicate: VC_VALID_FROM,
-                object: Term::Literal(Literal::Typed {
-                    value: credential.valid_from,
-                    datatype: RDF_DATE_TYPE,
+                predicate: VC_TYPE,
+                object: Term::NamedNode(NamedNode {
+                    iri: credential.r#type,
                 }),
             },
             Triple {
                 subject: c_subject,
-                predicate: RDF_TYPE,
-                object: Term::NamedNode(NamedNode {
-                    iri: credential.r#type,
+                predicate: VC_VALID_FROM,
+                object: Term::Literal(Literal::Typed {
+                    value: credential.valid_from,
+                    datatype: RDF_DATE_TYPE,
                 }),
             },
             Triple {

--- a/contracts/okp4-dataverse/src/registrar/rdf.rs
+++ b/contracts/okp4-dataverse/src/registrar/rdf.rs
@@ -104,3 +104,42 @@ pub fn serialize(
         StdError::serialize_err("triple", format!("Error writing triple: {e}"))
     })?))
 }
+
+#[cfg(test)]
+mod test {
+    use super::*;
+    use crate::credential::vc::VerifiableCredential;
+    use crate::testutil::testutil;
+    use cosmwasm_std::Addr;
+    use okp4_rdf::dataset::Dataset;
+
+    #[test]
+    fn proper_serialization() {
+        let owned_quads = testutil::read_test_quads("vc-valid.nq");
+        let dataset = Dataset::from(owned_quads.as_slice());
+        let vc = VerifiableCredential::try_from(&dataset).unwrap();
+        let dc = DataverseCredential::try_from((
+            Addr::unchecked("okp41072nc6egexqr2v6vpp7yxwm68plvqnkf6xsytf"),
+            &vc,
+        ))
+        .unwrap();
+
+        let expected = "<https://w3id.org/okp4/ontology/vnext/schema/credential/digital-service/description/72cab400-5bd6-4eb4-8605-a5ee8c1a45c9> <dataverse:credential#submitterAddress> <okp41072nc6egexqr2v6vpp7yxwm68plvqnkf6xsytf> .
+<https://w3id.org/okp4/ontology/vnext/schema/credential/digital-service/description/72cab400-5bd6-4eb4-8605-a5ee8c1a45c9> <dataverse:credential#issuer> <did:key:zQ3shs7auhJSmVJpiUbQWco6bxxEhSqWnVEPvaBHBRvBKw6Q3> .
+<https://w3id.org/okp4/ontology/vnext/schema/credential/digital-service/description/72cab400-5bd6-4eb4-8605-a5ee8c1a45c9> <dataverse:credential#type> <https://w3id.org/okp4/ontology/vnext/schema/credential/digital-service/description/DigitalServiceDescriptionCredential> .
+<https://w3id.org/okp4/ontology/vnext/schema/credential/digital-service/description/72cab400-5bd6-4eb4-8605-a5ee8c1a45c9> <dataverse:credential#validFrom> \"2024-01-22T00:00:00\"^^<http://www.w3.org/2001/XMLSchema#dateTime> .
+<https://w3id.org/okp4/ontology/vnext/schema/credential/digital-service/description/72cab400-5bd6-4eb4-8605-a5ee8c1a45c9> <dataverse:credential#subject> <did:key:zQ3shhb4SvzBRLbBonsvKb3WX6WoDeKWHpsXXXMhAJETqXAfB> .
+_:c0 <https://w3id.org/okp4/ontology/vnext/schema/credential/digital-service/description/hasCategory> <https://w3id.org/okp4/ontology/vnext/thesaurus/digital-service-category/Storage> .
+_:c0 <https://w3id.org/okp4/ontology/vnext/schema/credential/digital-service/description/hasTag> \"Cloud\" .
+<https://w3id.org/okp4/ontology/vnext/schema/credential/digital-service/description/72cab400-5bd6-4eb4-8605-a5ee8c1a45c9> <dataverse:credential#claim> _:c0 .
+<https://w3id.org/okp4/ontology/vnext/schema/credential/digital-service/description/72cab400-5bd6-4eb4-8605-a5ee8c1a45c9> <dataverse:credential#validUntil> \"2025-01-22T00:00:00\"^^<http://www.w3.org/2001/XMLSchema#dateTime> .\n";
+
+        let serialization_res = serialize(&dc, DataFormat::NQuads);
+        assert!(serialization_res.is_ok());
+
+        assert_eq!(
+            String::from_utf8(serialization_res.unwrap().0).unwrap(),
+            expected
+        );
+    }
+}

--- a/contracts/okp4-dataverse/src/registrar/rdf.rs
+++ b/contracts/okp4-dataverse/src/registrar/rdf.rs
@@ -35,8 +35,8 @@ impl<'a> From<&'a DataverseCredential<'a>> for Vec<Triple<'a>> {
             Triple {
                 subject: c_subject,
                 predicate: VC_SUBMITTER_ADDRESS,
-                object: Term::NamedNode(NamedNode {
-                    iri: credential.submitter_addr.as_str(),
+                object: Term::Literal(Literal::Simple {
+                    value: credential.submitter_addr.as_str(),
                 }),
             },
             Triple {
@@ -124,7 +124,7 @@ mod test {
         ))
         .unwrap();
 
-        let expected = "<https://w3id.org/okp4/ontology/vnext/schema/credential/digital-service/description/72cab400-5bd6-4eb4-8605-a5ee8c1a45c9> <dataverse:credential#submitterAddress> <okp41072nc6egexqr2v6vpp7yxwm68plvqnkf6xsytf> .
+        let expected = "<https://w3id.org/okp4/ontology/vnext/schema/credential/digital-service/description/72cab400-5bd6-4eb4-8605-a5ee8c1a45c9> <dataverse:credential#submitterAddress> \"okp41072nc6egexqr2v6vpp7yxwm68plvqnkf6xsytf\" .
 <https://w3id.org/okp4/ontology/vnext/schema/credential/digital-service/description/72cab400-5bd6-4eb4-8605-a5ee8c1a45c9> <dataverse:credential#issuer> <did:key:zQ3shs7auhJSmVJpiUbQWco6bxxEhSqWnVEPvaBHBRvBKw6Q3> .
 <https://w3id.org/okp4/ontology/vnext/schema/credential/digital-service/description/72cab400-5bd6-4eb4-8605-a5ee8c1a45c9> <dataverse:credential#type> <https://w3id.org/okp4/ontology/vnext/schema/credential/digital-service/description/DigitalServiceDescriptionCredential> .
 <https://w3id.org/okp4/ontology/vnext/schema/credential/digital-service/description/72cab400-5bd6-4eb4-8605-a5ee8c1a45c9> <dataverse:credential#validFrom> \"2024-01-22T00:00:00\"^^<http://www.w3.org/2001/XMLSchema#dateTime> .

--- a/contracts/okp4-dataverse/src/registrar/rdf.rs
+++ b/contracts/okp4-dataverse/src/registrar/rdf.rs
@@ -1,0 +1,123 @@
+use crate::credential::rdf_marker::{RDF_DATE_TYPE, RDF_TYPE};
+use crate::registrar::credential::DataverseCredential;
+use crate::ContractError;
+use cosmwasm_std::{Binary, StdError};
+use okp4_rdf::serde::{DataFormat, TripleWriter};
+use rio_api::model::{BlankNode, Literal, NamedNode, Subject, Term, Triple};
+
+pub const VC_SUBMITTER_ADDRESS: NamedNode<'_> = NamedNode {
+    iri: "dataverse:credential#submitterAddress",
+};
+pub const VC_ISSUER: NamedNode<'_> = NamedNode {
+    iri: "dataverse:credential#issuer",
+};
+pub const VC_VALID_FROM: NamedNode<'_> = NamedNode {
+    iri: "dataverse:credential#validFrom",
+};
+pub const VC_VALID_UNTIL: NamedNode<'_> = NamedNode {
+    iri: "dataverse:credential#validUntil",
+};
+pub const VC_SUBJECT: NamedNode<'_> = NamedNode {
+    iri: "dataverse:credential#subject",
+};
+pub const VC_CLAIM: NamedNode<'_> = NamedNode {
+    iri: "dataverse:credential#claim",
+};
+
+impl<'a> TryFrom<&'a DataverseCredential<'a>> for Vec<Triple<'a>> {
+    type Error = ContractError;
+
+    fn try_from(credential: &'a DataverseCredential<'a>) -> Result<Self, Self::Error> {
+        let c_subject = Subject::NamedNode(NamedNode { iri: credential.id });
+        let claim_node = BlankNode { id: "c0" };
+
+        let mut triples = vec![
+            Triple {
+                subject: c_subject,
+                predicate: VC_SUBMITTER_ADDRESS,
+                object: Term::NamedNode(NamedNode {
+                    iri: credential.submitter_addr.as_str(),
+                }),
+            },
+            Triple {
+                subject: c_subject,
+                predicate: VC_ISSUER,
+                object: Term::NamedNode(NamedNode {
+                    iri: credential.issuer,
+                }),
+            },
+            Triple {
+                subject: c_subject,
+                predicate: VC_VALID_FROM,
+                object: Term::Literal(Literal::Typed {
+                    value: credential.valid_from,
+                    datatype: RDF_DATE_TYPE,
+                }),
+            },
+            Triple {
+                subject: c_subject,
+                predicate: RDF_TYPE,
+                object: Term::NamedNode(NamedNode {
+                    iri: credential.r#type,
+                }),
+            },
+            Triple {
+                subject: c_subject,
+                predicate: VC_SUBJECT,
+                object: Term::NamedNode(NamedNode {
+                    iri: credential.subject,
+                }),
+            },
+            Triple {
+                subject: c_subject,
+                predicate: VC_CLAIM,
+                object: Term::BlankNode(claim_node),
+            },
+        ];
+
+        triples.extend(credential.claim.iter().map(|q| {
+            let subject = match q.subject {
+                Subject::NamedNode(n) if n.iri == credential.subject => {
+                    Subject::BlankNode(claim_node)
+                }
+                _ => q.subject,
+            };
+            Triple {
+                subject,
+                predicate: q.predicate,
+                object: q.object,
+            }
+        }));
+
+        if let Some(valid_until) = credential.valid_until {
+            triples.push(Triple {
+                subject: c_subject,
+                predicate: VC_VALID_UNTIL,
+                object: Term::Literal(Literal::Typed {
+                    value: valid_until,
+                    datatype: RDF_DATE_TYPE,
+                }),
+            });
+        }
+
+        Ok(triples)
+    }
+}
+
+pub fn serialize(
+    credential: &DataverseCredential<'_>,
+    format: DataFormat,
+) -> Result<Binary, ContractError> {
+    let triples: Vec<Triple<'_>> = credential.try_into()?;
+    let out: Vec<u8> = Vec::default();
+    let mut writer = TripleWriter::new(&format, out);
+    for triple in triples {
+        writer
+            .write(&triple)
+            .map_err(|e| StdError::serialize_err("triple", format!("Error writing triple: {e}")))?;
+    }
+
+    Ok(Binary::from(writer.finish().map_err(|e| {
+        StdError::serialize_err("triple", format!("Error writing triple: {e}"))
+    })?))
+}

--- a/contracts/okp4-dataverse/src/registrar/registry.rs
+++ b/contracts/okp4-dataverse/src/registrar/registry.rs
@@ -1,0 +1,65 @@
+use crate::registrar::credential::DataverseCredential;
+use crate::registrar::rdf::serialize;
+use crate::state::DATAVERSE;
+use crate::ContractError;
+use cosmwasm_std::{DepsMut, StdResult, Storage, WasmMsg};
+use okp4_cognitarium::msg::{
+    DataFormat, Node, SelectItem, SelectQuery, SimpleWhereCondition, TriplePattern, VarOrNode,
+    VarOrNodeOrLiteral, WhereCondition, IRI,
+};
+use okp4_cognitarium_client::CognitariumClient;
+
+/// ClaimRegistrar is the entity responsible to manage claims (i.e. submission and revocation) into
+/// the Dataverse, ensuring that any pre-condition criteria to an action is met, and any attached
+/// logic is properly executed.
+pub struct ClaimRegistrar {
+    triplestore: CognitariumClient,
+}
+
+impl ClaimRegistrar {
+    const RDF_DATA_FORMAT: DataFormat = DataFormat::NTriples;
+
+    pub fn try_new(storage: &dyn Storage) -> StdResult<Self> {
+        let dataverse = DATAVERSE.load(storage)?;
+        Ok(Self {
+            triplestore: CognitariumClient::new(dataverse.triplestore_address),
+        })
+    }
+
+    pub fn submit_claim(
+        &self,
+        deps: &DepsMut<'_>,
+        credential: &DataverseCredential<'_>,
+    ) -> Result<WasmMsg, ContractError> {
+        let resp = self.triplestore.select(
+            deps.querier,
+            SelectQuery {
+                prefixes: vec![],
+                limit: Some(1u32),
+                select: vec![SelectItem::Variable("p".to_string())],
+                r#where: vec![WhereCondition::Simple(SimpleWhereCondition::TriplePattern(
+                    TriplePattern {
+                        subject: VarOrNode::Node(Node::NamedNode(IRI::Full(
+                            credential.id.to_string(),
+                        ))),
+                        predicate: VarOrNode::Variable("p".to_string()),
+                        object: VarOrNodeOrLiteral::Variable("o".to_string()),
+                    },
+                ))],
+            },
+        )?;
+
+        if !resp.results.bindings.is_empty() {
+            Err(ContractError::CredentialAlreadyExists(
+                credential.id.to_string(),
+            ))?;
+        }
+
+        self.triplestore
+            .insert_data(
+                Some(Self::RDF_DATA_FORMAT),
+                serialize(credential, (&Self::RDF_DATA_FORMAT).into())?,
+            )
+            .map_err(ContractError::from)
+    }
+}

--- a/contracts/okp4-dataverse/testdata/vc-eddsa-2020-ok-unsecured.nq
+++ b/contracts/okp4-dataverse/testdata/vc-eddsa-2020-ok-unsecured.nq
@@ -1,4 +1,9 @@
-<http://example.edu/credentials/58473> <http://www.w3.org/1999/02/22-rdf-syntax-ns#type> <https://www.w3.org/2018/credentials#VerifiableCredential> .
-<http://example.edu/credentials/58473> <https://www.w3.org/2018/credentials#credentialSubject> <did:key:z6MkpwdnLPAm4apwcrRYQ6fZ3rAcqjLZR4AMk14vimfnozqY> .
-<http://example.edu/credentials/58473> <https://www.w3.org/2018/credentials#issuanceDate> "2023-05-01T06:09:10Z"^^<http://www.w3.org/2001/XMLSchema#dateTime> .
-<http://example.edu/credentials/58473> <https://www.w3.org/2018/credentials#issuer> <did:key:z6MkpwdnLPAm4apwcrRYQ6fZ3rAcqjLZR4AMk14vimfnozqY> .
+<did:key:zDnaeUm3QkcyZWZTPttxB711jgqRDhkwvhF485SFw1bDZ9AQw> <https://example.org/examples#degree> _:b2 .
+<http://example.edu/credentials/3732> <http://www.w3.org/1999/02/22-rdf-syntax-ns#type> <https://example.org/examples#UniversityDegreeCredential> .
+<http://example.edu/credentials/3732> <http://www.w3.org/1999/02/22-rdf-syntax-ns#type> <https://www.w3.org/2018/credentials#VerifiableCredential> .
+<http://example.edu/credentials/3732> <https://www.w3.org/2018/credentials#credentialSubject> <did:key:zDnaeUm3QkcyZWZTPttxB711jgqRDhkwvhF485SFw1bDZ9AQw> .
+<http://example.edu/credentials/3732> <https://www.w3.org/2018/credentials#expirationDate> "2026-02-16T00:00:00Z"^^<http://www.w3.org/2001/XMLSchema#dateTime> .
+<http://example.edu/credentials/3732> <https://www.w3.org/2018/credentials#issuanceDate> "2024-02-16T00:00:00Z"^^<http://www.w3.org/2001/XMLSchema#dateTime> .
+<http://example.edu/credentials/3732> <https://www.w3.org/2018/credentials#issuer> <did:key:z6MkpwdnLPAm4apwcrRYQ6fZ3rAcqjLZR4AMk14vimfnozqY> .
+_:b2 <http://schema.org/name> "Bachelor of Science and Arts"^^<http://www.w3.org/1999/02/22-rdf-syntax-ns#HTML> .
+_:b2 <http://www.w3.org/1999/02/22-rdf-syntax-ns#type> <https://example.org/examples#BachelorDegree> .

--- a/contracts/okp4-dataverse/testdata/vc-eddsa-2020-ok.nq
+++ b/contracts/okp4-dataverse/testdata/vc-eddsa-2020-ok.nq
@@ -1,10 +1,15 @@
-<http://example.edu/credentials/58473> <http://www.w3.org/1999/02/22-rdf-syntax-ns#type> <https://www.w3.org/2018/credentials#VerifiableCredential> .
-<http://example.edu/credentials/58473> <https://w3id.org/security#proof> _:b0 .
-<http://example.edu/credentials/58473> <https://www.w3.org/2018/credentials#credentialSubject> <did:key:z6MkpwdnLPAm4apwcrRYQ6fZ3rAcqjLZR4AMk14vimfnozqY> .
-<http://example.edu/credentials/58473> <https://www.w3.org/2018/credentials#issuanceDate> "2023-05-01T06:09:10Z"^^<http://www.w3.org/2001/XMLSchema#dateTime> .
-<http://example.edu/credentials/58473> <https://www.w3.org/2018/credentials#issuer> <did:key:z6MkpwdnLPAm4apwcrRYQ6fZ3rAcqjLZR4AMk14vimfnozqY> .
-_:b1 <http://purl.org/dc/terms/created> "2024-02-01T17:46:53.676947Z"^^<http://www.w3.org/2001/XMLSchema#dateTime> _:b0 .
+<did:key:zDnaeUm3QkcyZWZTPttxB711jgqRDhkwvhF485SFw1bDZ9AQw> <https://example.org/examples#degree> _:b2 .
+<http://example.edu/credentials/3732> <http://www.w3.org/1999/02/22-rdf-syntax-ns#type> <https://example.org/examples#UniversityDegreeCredential> .
+<http://example.edu/credentials/3732> <http://www.w3.org/1999/02/22-rdf-syntax-ns#type> <https://www.w3.org/2018/credentials#VerifiableCredential> .
+<http://example.edu/credentials/3732> <https://w3id.org/security#proof> _:b0 .
+<http://example.edu/credentials/3732> <https://www.w3.org/2018/credentials#credentialSubject> <did:key:zDnaeUm3QkcyZWZTPttxB711jgqRDhkwvhF485SFw1bDZ9AQw> .
+<http://example.edu/credentials/3732> <https://www.w3.org/2018/credentials#expirationDate> "2026-02-16T00:00:00Z"^^<http://www.w3.org/2001/XMLSchema#dateTime> .
+<http://example.edu/credentials/3732> <https://www.w3.org/2018/credentials#issuanceDate> "2024-02-16T00:00:00Z"^^<http://www.w3.org/2001/XMLSchema#dateTime> .
+<http://example.edu/credentials/3732> <https://www.w3.org/2018/credentials#issuer> <did:key:z6MkpwdnLPAm4apwcrRYQ6fZ3rAcqjLZR4AMk14vimfnozqY> .
+_:b1 <http://purl.org/dc/terms/created> "2024-02-16T17:35:56.668169Z"^^<http://www.w3.org/2001/XMLSchema#dateTime> _:b0 .
 _:b1 <http://www.w3.org/1999/02/22-rdf-syntax-ns#type> <https://w3id.org/security#Ed25519Signature2020> _:b0 .
 _:b1 <https://w3id.org/security#proofPurpose> <https://w3id.org/security#assertionMethod> _:b0 .
-_:b1 <https://w3id.org/security#proofValue> "z3WboEDRwsWokH8vQrveVWbg6fQnqhHfhrkGHT9tyG2GYgzQVZ9zFW6eK2ZNcnGhydqXWDwwTsZq29e7cHJkbnVkF"^^<https://w3id.org/security#multibase> _:b0 .
+_:b1 <https://w3id.org/security#proofValue> "zUuTPsT5aKs53ciMY6qEj2dqZxK4XnLoZhX26amB9GMCMhfcTmLbtndcW5JS4gUqPkxGxsCmZCKuvkFnDgrGFrWD"^^<https://w3id.org/security#multibase> _:b0 .
 _:b1 <https://w3id.org/security#verificationMethod> <did:key:z6MkpwdnLPAm4apwcrRYQ6fZ3rAcqjLZR4AMk14vimfnozqY#z6MkpwdnLPAm4apwcrRYQ6fZ3rAcqjLZR4AMk14vimfnozqY> _:b0 .
+_:b2 <http://schema.org/name> "Bachelor of Science and Arts"^^<http://www.w3.org/1999/02/22-rdf-syntax-ns#HTML> .
+_:b2 <http://www.w3.org/1999/02/22-rdf-syntax-ns#type> <https://example.org/examples#BachelorDegree> .

--- a/contracts/okp4-dataverse/testdata/vc-unsupported-1.nq
+++ b/contracts/okp4-dataverse/testdata/vc-unsupported-1.nq
@@ -1,0 +1,13 @@
+<did:key:zQ3shhb4SvzBRLbBonsvKb3WX6WoDeKWHpsXXXMhAJETqXAfB> <https://w3id.org/okp4/ontology/vnext/schema/credential/digital-service/description/hasCategory> <https://w3id.org/okp4/ontology/vnext/thesaurus/digital-service-category/Storage> .
+<did:key:zQ3shhb4SvzBRLbBonsvKb3WX6WoDeKWHpsXXXMhAJETqXAfB> <https://w3id.org/okp4/ontology/vnext/schema/credential/digital-service/description/hasTag> "Cloud" .
+<https://w3id.org/okp4/ontology/vnext/schema/credential/digital-service/description/72cab400-5bd6-4eb4-8605-a5ee8c1a45c9> <http://www.w3.org/1999/02/22-rdf-syntax-ns#type> <https://www.w3.org/2018/credentials#VerifiableCredential> .
+<https://w3id.org/okp4/ontology/vnext/schema/credential/digital-service/description/72cab400-5bd6-4eb4-8605-a5ee8c1a45c9> <https://www.w3.org/2018/credentials#credentialSubject> <did:key:zQ3shhb4SvzBRLbBonsvKb3WX6WoDeKWHpsXXXMhAJETqXAfB> .
+<https://w3id.org/okp4/ontology/vnext/schema/credential/digital-service/description/72cab400-5bd6-4eb4-8605-a5ee8c1a45c9> <https://www.w3.org/2018/credentials#issuanceDate> "2024-01-22T00:00:00"^^<http://www.w3.org/2001/XMLSchema#dateTime> .
+<https://w3id.org/okp4/ontology/vnext/schema/credential/digital-service/description/72cab400-5bd6-4eb4-8605-a5ee8c1a45c9> <https://www.w3.org/2018/credentials#expirationDate> "2025-01-22T00:00:00"^^<http://www.w3.org/2001/XMLSchema#dateTime> .
+<https://w3id.org/okp4/ontology/vnext/schema/credential/digital-service/description/72cab400-5bd6-4eb4-8605-a5ee8c1a45c9> <https://www.w3.org/2018/credentials#issuer> <did:key:zQ3shs7auhJSmVJpiUbQWco6bxxEhSqWnVEPvaBHBRvBKw6Q3> .
+<https://w3id.org/okp4/ontology/vnext/schema/credential/digital-service/description/72cab400-5bd6-4eb4-8605-a5ee8c1a45c9> <https://w3id.org/security#proof> _:b0 .
+_:b1 <http://purl.org/dc/terms/created> "2024-02-01T17:46:53.676947Z"^^<http://www.w3.org/2001/XMLSchema#dateTime> _:b0 .
+_:b1 <http://www.w3.org/1999/02/22-rdf-syntax-ns#type> <https://w3id.org/security#Ed25519Signature2020> _:b0 .
+_:b1 <https://w3id.org/security#proofPurpose> <https://w3id.org/security#assertionMethod> _:b0 .
+_:b1 <https://w3id.org/security#proofValue> "z3WboEDRwsWokH8vQrveVWbg6fQnqhHfhrkGHT9tyG2GYgzQVZ9zFW6eK2ZNcnGhydqXWDwwTsZq29e7cHJkbnVkF"^^<https://w3id.org/security#multibase> _:b0 .
+_:b1 <https://w3id.org/security#verificationMethod> <did:key:z6MkpwdnLPAm4apwcrRYQ6fZ3rAcqjLZR4AMk14vimfnozqY#z6MkpwdnLPAm4apwcrRYQ6fZ3rAcqjLZR4AMk14vimfnozqY> _:b0 .

--- a/contracts/okp4-dataverse/testdata/vc-unsupported-1.nq
+++ b/contracts/okp4-dataverse/testdata/vc-unsupported-1.nq
@@ -1,13 +1,14 @@
-<did:key:zQ3shhb4SvzBRLbBonsvKb3WX6WoDeKWHpsXXXMhAJETqXAfB> <https://w3id.org/okp4/ontology/vnext/schema/credential/digital-service/description/hasCategory> <https://w3id.org/okp4/ontology/vnext/thesaurus/digital-service-category/Storage> .
-<did:key:zQ3shhb4SvzBRLbBonsvKb3WX6WoDeKWHpsXXXMhAJETqXAfB> <https://w3id.org/okp4/ontology/vnext/schema/credential/digital-service/description/hasTag> "Cloud" .
-<https://w3id.org/okp4/ontology/vnext/schema/credential/digital-service/description/72cab400-5bd6-4eb4-8605-a5ee8c1a45c9> <http://www.w3.org/1999/02/22-rdf-syntax-ns#type> <https://www.w3.org/2018/credentials#VerifiableCredential> .
-<https://w3id.org/okp4/ontology/vnext/schema/credential/digital-service/description/72cab400-5bd6-4eb4-8605-a5ee8c1a45c9> <https://www.w3.org/2018/credentials#credentialSubject> <did:key:zQ3shhb4SvzBRLbBonsvKb3WX6WoDeKWHpsXXXMhAJETqXAfB> .
-<https://w3id.org/okp4/ontology/vnext/schema/credential/digital-service/description/72cab400-5bd6-4eb4-8605-a5ee8c1a45c9> <https://www.w3.org/2018/credentials#issuanceDate> "2024-01-22T00:00:00"^^<http://www.w3.org/2001/XMLSchema#dateTime> .
-<https://w3id.org/okp4/ontology/vnext/schema/credential/digital-service/description/72cab400-5bd6-4eb4-8605-a5ee8c1a45c9> <https://www.w3.org/2018/credentials#expirationDate> "2025-01-22T00:00:00"^^<http://www.w3.org/2001/XMLSchema#dateTime> .
-<https://w3id.org/okp4/ontology/vnext/schema/credential/digital-service/description/72cab400-5bd6-4eb4-8605-a5ee8c1a45c9> <https://www.w3.org/2018/credentials#issuer> <did:key:zQ3shs7auhJSmVJpiUbQWco6bxxEhSqWnVEPvaBHBRvBKw6Q3> .
-<https://w3id.org/okp4/ontology/vnext/schema/credential/digital-service/description/72cab400-5bd6-4eb4-8605-a5ee8c1a45c9> <https://w3id.org/security#proof> _:b0 .
-_:b1 <http://purl.org/dc/terms/created> "2024-02-01T17:46:53.676947Z"^^<http://www.w3.org/2001/XMLSchema#dateTime> _:b0 .
+<did:key:zDnaeUm3QkcyZWZTPttxB711jgqRDhkwvhF485SFw1bDZ9AQw> <https://example.org/examples#degree> _:b2 .
+<http://example.edu/credentials/3732> <http://www.w3.org/1999/02/22-rdf-syntax-ns#type> <https://www.w3.org/2018/credentials#VerifiableCredential> .
+<http://example.edu/credentials/3732> <https://w3id.org/security#proof> _:b0 .
+<http://example.edu/credentials/3732> <https://www.w3.org/2018/credentials#credentialSubject> <did:key:zDnaeUm3QkcyZWZTPttxB711jgqRDhkwvhF485SFw1bDZ9AQw> .
+<http://example.edu/credentials/3732> <https://www.w3.org/2018/credentials#expirationDate> "2026-02-16T00:00:00Z"^^<http://www.w3.org/2001/XMLSchema#dateTime> .
+<http://example.edu/credentials/3732> <https://www.w3.org/2018/credentials#issuanceDate> "2024-02-16T00:00:00Z"^^<http://www.w3.org/2001/XMLSchema#dateTime> .
+<http://example.edu/credentials/3732> <https://www.w3.org/2018/credentials#issuer> <did:key:z6MkpwdnLPAm4apwcrRYQ6fZ3rAcqjLZR4AMk14vimfnozqY> .
+_:b1 <http://purl.org/dc/terms/created> "2024-02-17T13:32:14.814613Z"^^<http://www.w3.org/2001/XMLSchema#dateTime> _:b0 .
 _:b1 <http://www.w3.org/1999/02/22-rdf-syntax-ns#type> <https://w3id.org/security#Ed25519Signature2020> _:b0 .
 _:b1 <https://w3id.org/security#proofPurpose> <https://w3id.org/security#assertionMethod> _:b0 .
-_:b1 <https://w3id.org/security#proofValue> "z3WboEDRwsWokH8vQrveVWbg6fQnqhHfhrkGHT9tyG2GYgzQVZ9zFW6eK2ZNcnGhydqXWDwwTsZq29e7cHJkbnVkF"^^<https://w3id.org/security#multibase> _:b0 .
+_:b1 <https://w3id.org/security#proofValue> "z5vGstniEMfyk5riV1UQvFXhXzdcbZ1978JFGdn1H2wTdp6qvxqDuw5xg8M33hjdZTG6zGuCbAhgCqf7R2CkhVRp5"^^<https://w3id.org/security#multibase> _:b0 .
 _:b1 <https://w3id.org/security#verificationMethod> <did:key:z6MkpwdnLPAm4apwcrRYQ6fZ3rAcqjLZR4AMk14vimfnozqY#z6MkpwdnLPAm4apwcrRYQ6fZ3rAcqjLZR4AMk14vimfnozqY> _:b0 .
+_:b2 <http://schema.org/name> "Bachelor of Science and Arts"^^<http://www.w3.org/1999/02/22-rdf-syntax-ns#HTML> .
+_:b2 <http://www.w3.org/1999/02/22-rdf-syntax-ns#type> <https://example.org/examples#BachelorDegree> .

--- a/contracts/okp4-dataverse/testdata/vc-unsupported-2.nq
+++ b/contracts/okp4-dataverse/testdata/vc-unsupported-2.nq
@@ -1,0 +1,15 @@
+<did:key:zQ3shhb4SvzBRLbBonsvKb3WX6WoDeKWHpsXXXMhAJETqXAfB> <https://w3id.org/okp4/ontology/vnext/schema/credential/digital-service/description/hasCategory> <https://w3id.org/okp4/ontology/vnext/thesaurus/digital-service-category/Storage> .
+<did:key:zQ3shhb4SvzBRLbBonsvKb3WX6WoDeKWHpsXXXMhAJETqXAfB> <https://w3id.org/okp4/ontology/vnext/schema/credential/digital-service/description/hasTag> "Cloud" .
+<https://w3id.org/okp4/ontology/vnext/schema/credential/digital-service/description/72cab400-5bd6-4eb4-8605-a5ee8c1a45c9> <http://www.w3.org/1999/02/22-rdf-syntax-ns#type> <https://w3id.org/okp4/ontology/vnext/schema/credential/digital-service/description/DigitalServiceDescriptionCredential> .
+<https://w3id.org/okp4/ontology/vnext/schema/credential/digital-service/description/72cab400-5bd6-4eb4-8605-a5ee8c1a45c9> <http://www.w3.org/1999/02/22-rdf-syntax-ns#type> <https://w3id.org/okp4/ontology/vnext/schema/credential/digital-service/description/DigitalServiceDescriptionCredential2> .
+<https://w3id.org/okp4/ontology/vnext/schema/credential/digital-service/description/72cab400-5bd6-4eb4-8605-a5ee8c1a45c9> <http://www.w3.org/1999/02/22-rdf-syntax-ns#type> <https://www.w3.org/2018/credentials#VerifiableCredential> .
+<https://w3id.org/okp4/ontology/vnext/schema/credential/digital-service/description/72cab400-5bd6-4eb4-8605-a5ee8c1a45c9> <https://www.w3.org/2018/credentials#credentialSubject> <did:key:zQ3shhb4SvzBRLbBonsvKb3WX6WoDeKWHpsXXXMhAJETqXAfB> .
+<https://w3id.org/okp4/ontology/vnext/schema/credential/digital-service/description/72cab400-5bd6-4eb4-8605-a5ee8c1a45c9> <https://www.w3.org/2018/credentials#issuanceDate> "2024-01-22T00:00:00"^^<http://www.w3.org/2001/XMLSchema#dateTime> .
+<https://w3id.org/okp4/ontology/vnext/schema/credential/digital-service/description/72cab400-5bd6-4eb4-8605-a5ee8c1a45c9> <https://www.w3.org/2018/credentials#expirationDate> "2025-01-22T00:00:00"^^<http://www.w3.org/2001/XMLSchema#dateTime> .
+<https://w3id.org/okp4/ontology/vnext/schema/credential/digital-service/description/72cab400-5bd6-4eb4-8605-a5ee8c1a45c9> <https://www.w3.org/2018/credentials#issuer> <did:key:zQ3shs7auhJSmVJpiUbQWco6bxxEhSqWnVEPvaBHBRvBKw6Q3> .
+<https://w3id.org/okp4/ontology/vnext/schema/credential/digital-service/description/72cab400-5bd6-4eb4-8605-a5ee8c1a45c9> <https://w3id.org/security#proof> _:b0 .
+_:b1 <http://purl.org/dc/terms/created> "2024-02-01T17:46:53.676947Z"^^<http://www.w3.org/2001/XMLSchema#dateTime> _:b0 .
+_:b1 <http://www.w3.org/1999/02/22-rdf-syntax-ns#type> <https://w3id.org/security#Ed25519Signature2020> _:b0 .
+_:b1 <https://w3id.org/security#proofPurpose> <https://w3id.org/security#assertionMethod> _:b0 .
+_:b1 <https://w3id.org/security#proofValue> "z3WboEDRwsWokH8vQrveVWbg6fQnqhHfhrkGHT9tyG2GYgzQVZ9zFW6eK2ZNcnGhydqXWDwwTsZq29e7cHJkbnVkF"^^<https://w3id.org/security#multibase> _:b0 .
+_:b1 <https://w3id.org/security#verificationMethod> <did:key:z6MkpwdnLPAm4apwcrRYQ6fZ3rAcqjLZR4AMk14vimfnozqY#z6MkpwdnLPAm4apwcrRYQ6fZ3rAcqjLZR4AMk14vimfnozqY> _:b0 .

--- a/contracts/okp4-dataverse/testdata/vc-unsupported-3.nq
+++ b/contracts/okp4-dataverse/testdata/vc-unsupported-3.nq
@@ -1,0 +1,16 @@
+<did:key:zQ3shhb4SvzBRLbBonsvKb3WX6WoDeKWHpsXXXMhAJETqXAfB> <https://w3id.org/okp4/ontology/vnext/schema/credential/digital-service/description/hasCategory> <https://w3id.org/okp4/ontology/vnext/thesaurus/digital-service-category/Storage> .
+<did:key:zQ3shhb4SvzBRLbBonsvKb3WX6WoDeKWHpsXXXMhAJETqXAfB> <https://w3id.org/okp4/ontology/vnext/schema/credential/digital-service/description/hasTag> "Cloud" .
+<did:key:z6MkpwdnLPAm4apwcrRYQ6fZ3rAcqjLZR4AMk14vimfnozqY> <https://w3id.org/okp4/ontology/vnext/schema/credential/digital-service/description/hasTag> "Cloud" .
+<https://w3id.org/okp4/ontology/vnext/schema/credential/digital-service/description/72cab400-5bd6-4eb4-8605-a5ee8c1a45c9> <http://www.w3.org/1999/02/22-rdf-syntax-ns#type> <https://w3id.org/okp4/ontology/vnext/schema/credential/digital-service/description/DigitalServiceDescriptionCredential> .
+<https://w3id.org/okp4/ontology/vnext/schema/credential/digital-service/description/72cab400-5bd6-4eb4-8605-a5ee8c1a45c9> <http://www.w3.org/1999/02/22-rdf-syntax-ns#type> <https://www.w3.org/2018/credentials#VerifiableCredential> .
+<https://w3id.org/okp4/ontology/vnext/schema/credential/digital-service/description/72cab400-5bd6-4eb4-8605-a5ee8c1a45c9> <https://www.w3.org/2018/credentials#credentialSubject> <did:key:zQ3shhb4SvzBRLbBonsvKb3WX6WoDeKWHpsXXXMhAJETqXAfB> .
+<https://w3id.org/okp4/ontology/vnext/schema/credential/digital-service/description/72cab400-5bd6-4eb4-8605-a5ee8c1a45c9> <https://www.w3.org/2018/credentials#credentialSubject> <did:key:z6MkpwdnLPAm4apwcrRYQ6fZ3rAcqjLZR4AMk14vimfnozqY> .
+<https://w3id.org/okp4/ontology/vnext/schema/credential/digital-service/description/72cab400-5bd6-4eb4-8605-a5ee8c1a45c9> <https://www.w3.org/2018/credentials#issuanceDate> "2024-01-22T00:00:00"^^<http://www.w3.org/2001/XMLSchema#dateTime> .
+<https://w3id.org/okp4/ontology/vnext/schema/credential/digital-service/description/72cab400-5bd6-4eb4-8605-a5ee8c1a45c9> <https://www.w3.org/2018/credentials#expirationDate> "2025-01-22T00:00:00"^^<http://www.w3.org/2001/XMLSchema#dateTime> .
+<https://w3id.org/okp4/ontology/vnext/schema/credential/digital-service/description/72cab400-5bd6-4eb4-8605-a5ee8c1a45c9> <https://www.w3.org/2018/credentials#issuer> <did:key:zQ3shs7auhJSmVJpiUbQWco6bxxEhSqWnVEPvaBHBRvBKw6Q3> .
+<https://w3id.org/okp4/ontology/vnext/schema/credential/digital-service/description/72cab400-5bd6-4eb4-8605-a5ee8c1a45c9> <https://w3id.org/security#proof> _:b0 .
+_:b1 <http://purl.org/dc/terms/created> "2024-02-01T17:46:53.676947Z"^^<http://www.w3.org/2001/XMLSchema#dateTime> _:b0 .
+_:b1 <http://www.w3.org/1999/02/22-rdf-syntax-ns#type> <https://w3id.org/security#Ed25519Signature2020> _:b0 .
+_:b1 <https://w3id.org/security#proofPurpose> <https://w3id.org/security#assertionMethod> _:b0 .
+_:b1 <https://w3id.org/security#proofValue> "z3WboEDRwsWokH8vQrveVWbg6fQnqhHfhrkGHT9tyG2GYgzQVZ9zFW6eK2ZNcnGhydqXWDwwTsZq29e7cHJkbnVkF"^^<https://w3id.org/security#multibase> _:b0 .
+_:b1 <https://w3id.org/security#verificationMethod> <did:key:z6MkpwdnLPAm4apwcrRYQ6fZ3rAcqjLZR4AMk14vimfnozqY#z6MkpwdnLPAm4apwcrRYQ6fZ3rAcqjLZR4AMk14vimfnozqY> _:b0 .

--- a/contracts/okp4-dataverse/testdata/vc-unsupported-4.nq
+++ b/contracts/okp4-dataverse/testdata/vc-unsupported-4.nq
@@ -1,0 +1,16 @@
+<did:key:zQ3shhb4SvzBRLbBonsvKb3WX6WoDeKWHpsXXXMhAJETqXAfB> <https://w3id.org/okp4/ontology/vnext/schema/credential/digital-service/description/hasCategory> <https://w3id.org/okp4/ontology/vnext/thesaurus/digital-service-category/Storage> .
+<did:key:zQ3shhb4SvzBRLbBonsvKb3WX6WoDeKWHpsXXXMhAJETqXAfB> <https://w3id.org/okp4/ontology/vnext/schema/credential/digital-service/description/hasTag> "Cloud" .
+<did:key:zQ3shhb4SvzBRLbBonsvKb3WX6WoDeKWHpsXXXMhAJETqXAfB> <claim:hasSubElem> <claim:subElem> .
+<claim:subElem> <claim:isSubElem> "yes I am" .
+<https://w3id.org/okp4/ontology/vnext/schema/credential/digital-service/description/72cab400-5bd6-4eb4-8605-a5ee8c1a45c9> <http://www.w3.org/1999/02/22-rdf-syntax-ns#type> <https://w3id.org/okp4/ontology/vnext/schema/credential/digital-service/description/DigitalServiceDescriptionCredential> .
+<https://w3id.org/okp4/ontology/vnext/schema/credential/digital-service/description/72cab400-5bd6-4eb4-8605-a5ee8c1a45c9> <http://www.w3.org/1999/02/22-rdf-syntax-ns#type> <https://www.w3.org/2018/credentials#VerifiableCredential> .
+<https://w3id.org/okp4/ontology/vnext/schema/credential/digital-service/description/72cab400-5bd6-4eb4-8605-a5ee8c1a45c9> <https://www.w3.org/2018/credentials#credentialSubject> <did:key:zQ3shhb4SvzBRLbBonsvKb3WX6WoDeKWHpsXXXMhAJETqXAfB> .
+<https://w3id.org/okp4/ontology/vnext/schema/credential/digital-service/description/72cab400-5bd6-4eb4-8605-a5ee8c1a45c9> <https://www.w3.org/2018/credentials#issuanceDate> "2024-01-22T00:00:00"^^<http://www.w3.org/2001/XMLSchema#dateTime> .
+<https://w3id.org/okp4/ontology/vnext/schema/credential/digital-service/description/72cab400-5bd6-4eb4-8605-a5ee8c1a45c9> <https://www.w3.org/2018/credentials#expirationDate> "2025-01-22T00:00:00"^^<http://www.w3.org/2001/XMLSchema#dateTime> .
+<https://w3id.org/okp4/ontology/vnext/schema/credential/digital-service/description/72cab400-5bd6-4eb4-8605-a5ee8c1a45c9> <https://www.w3.org/2018/credentials#issuer> <did:key:zQ3shs7auhJSmVJpiUbQWco6bxxEhSqWnVEPvaBHBRvBKw6Q3> .
+<https://w3id.org/okp4/ontology/vnext/schema/credential/digital-service/description/72cab400-5bd6-4eb4-8605-a5ee8c1a45c9> <https://w3id.org/security#proof> _:b0 .
+_:b1 <http://purl.org/dc/terms/created> "2024-02-01T17:46:53.676947Z"^^<http://www.w3.org/2001/XMLSchema#dateTime> _:b0 .
+_:b1 <http://www.w3.org/1999/02/22-rdf-syntax-ns#type> <https://w3id.org/security#Ed25519Signature2020> _:b0 .
+_:b1 <https://w3id.org/security#proofPurpose> <https://w3id.org/security#assertionMethod> _:b0 .
+_:b1 <https://w3id.org/security#proofValue> "z3WboEDRwsWokH8vQrveVWbg6fQnqhHfhrkGHT9tyG2GYgzQVZ9zFW6eK2ZNcnGhydqXWDwwTsZq29e7cHJkbnVkF"^^<https://w3id.org/security#multibase> _:b0 .
+_:b1 <https://w3id.org/security#verificationMethod> <did:key:z6MkpwdnLPAm4apwcrRYQ6fZ3rAcqjLZR4AMk14vimfnozqY#z6MkpwdnLPAm4apwcrRYQ6fZ3rAcqjLZR4AMk14vimfnozqY> _:b0 .

--- a/contracts/okp4-dataverse/testdata/vc-valid.nq
+++ b/contracts/okp4-dataverse/testdata/vc-valid.nq
@@ -1,0 +1,14 @@
+<did:key:zQ3shhb4SvzBRLbBonsvKb3WX6WoDeKWHpsXXXMhAJETqXAfB> <https://w3id.org/okp4/ontology/vnext/schema/credential/digital-service/description/hasCategory> <https://w3id.org/okp4/ontology/vnext/thesaurus/digital-service-category/Storage> .
+<did:key:zQ3shhb4SvzBRLbBonsvKb3WX6WoDeKWHpsXXXMhAJETqXAfB> <https://w3id.org/okp4/ontology/vnext/schema/credential/digital-service/description/hasTag> "Cloud" .
+<https://w3id.org/okp4/ontology/vnext/schema/credential/digital-service/description/72cab400-5bd6-4eb4-8605-a5ee8c1a45c9> <http://www.w3.org/1999/02/22-rdf-syntax-ns#type> <https://w3id.org/okp4/ontology/vnext/schema/credential/digital-service/description/DigitalServiceDescriptionCredential> .
+<https://w3id.org/okp4/ontology/vnext/schema/credential/digital-service/description/72cab400-5bd6-4eb4-8605-a5ee8c1a45c9> <http://www.w3.org/1999/02/22-rdf-syntax-ns#type> <https://www.w3.org/2018/credentials#VerifiableCredential> .
+<https://w3id.org/okp4/ontology/vnext/schema/credential/digital-service/description/72cab400-5bd6-4eb4-8605-a5ee8c1a45c9> <https://www.w3.org/2018/credentials#credentialSubject> <did:key:zQ3shhb4SvzBRLbBonsvKb3WX6WoDeKWHpsXXXMhAJETqXAfB> .
+<https://w3id.org/okp4/ontology/vnext/schema/credential/digital-service/description/72cab400-5bd6-4eb4-8605-a5ee8c1a45c9> <https://www.w3.org/2018/credentials#issuanceDate> "2024-01-22T00:00:00"^^<http://www.w3.org/2001/XMLSchema#dateTime> .
+<https://w3id.org/okp4/ontology/vnext/schema/credential/digital-service/description/72cab400-5bd6-4eb4-8605-a5ee8c1a45c9> <https://www.w3.org/2018/credentials#expirationDate> "2025-01-22T00:00:00"^^<http://www.w3.org/2001/XMLSchema#dateTime> .
+<https://w3id.org/okp4/ontology/vnext/schema/credential/digital-service/description/72cab400-5bd6-4eb4-8605-a5ee8c1a45c9> <https://www.w3.org/2018/credentials#issuer> <did:key:zQ3shs7auhJSmVJpiUbQWco6bxxEhSqWnVEPvaBHBRvBKw6Q3> .
+<https://w3id.org/okp4/ontology/vnext/schema/credential/digital-service/description/72cab400-5bd6-4eb4-8605-a5ee8c1a45c9> <https://w3id.org/security#proof> _:b0 .
+_:b1 <http://purl.org/dc/terms/created> "2024-02-01T17:46:53.676947Z"^^<http://www.w3.org/2001/XMLSchema#dateTime> _:b0 .
+_:b1 <http://www.w3.org/1999/02/22-rdf-syntax-ns#type> <https://w3id.org/security#Ed25519Signature2020> _:b0 .
+_:b1 <https://w3id.org/security#proofPurpose> <https://w3id.org/security#assertionMethod> _:b0 .
+_:b1 <https://w3id.org/security#proofValue> "z3WboEDRwsWokH8vQrveVWbg6fQnqhHfhrkGHT9tyG2GYgzQVZ9zFW6eK2ZNcnGhydqXWDwwTsZq29e7cHJkbnVkF"^^<https://w3id.org/security#multibase> _:b0 .
+_:b1 <https://w3id.org/security#verificationMethod> <did:key:z6MkpwdnLPAm4apwcrRYQ6fZ3rAcqjLZR4AMk14vimfnozqY#z6MkpwdnLPAm4apwcrRYQ6fZ3rAcqjLZR4AMk14vimfnozqY> _:b0 .

--- a/docs/okp4-dataverse.md
+++ b/docs/okp4-dataverse.md
@@ -68,9 +68,7 @@ The SubmitClaims message is a pivotal component in the dataverse, enabling entit
 
 #### Format
 
-Claims are injected into the dataverse through Verifiable Presentations (VPs). These presentations effectively amalgamate and showcase multiple credentials, thus providing a cohesive and comprehensive view of the assertions being made.
-
-While the data in a VP typically revolves around a common subject, it accommodates an unlimited number of subjects and issuers. This flexibility allows for a broad spectrum of claims to be represented.
+Claims are injected into the dataverse through Verifiable Credentials (VCs).
 
 Primarily, the claims leverage the OKP4 ontology, which facilitates articulating assertions about widely acknowledged resources in the dataverse, including digital services, digital resources, zones, governance, and more.
 
@@ -80,11 +78,21 @@ Additionally, other schemas may also be employed to supplement and enhance the v
 
 To maintain integrity and coherence in the dataverse, several preconditions are set for the submission of claims:
 
-1. **Format Requirement**: Claims must be encapsulated within Verifiable Presentations (VPs).
+1. **Format Requirement**: Claims must be encapsulated within Verifiable Credentials (VCs).
 
 2. **Unique Identifier Mandate**: Each Verifiable Credential within the dataverse must possess a unique identifier.
 
 3. **Issuer Signature**: Claims must bear the issuer's signature. This signature must be verifiable, ensuring authenticity and credibility.
+
+4. **Content**: The actual implementation supports the submission of a single Verifiable Credential, containing a single claim.
+
+#### Supported cryptographic proofs
+
+- `Ed25519Signature2020`
+
+- `EcdsaSecp256k1Signature2019`
+
+- `DataIntegrity` with the following cryptosuites: `eddsa-2022`, `eddsa-rdfc-2022`.
 
 | parameter                | description                                                                                                                                                                  |
 | ------------------------ | ---------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
@@ -213,5 +221,5 @@ let b = Uint64::from(70u32); assert_eq!(b.u64(), 70); ```
 
 ---
 
-*Rendered by [Fadroma](https://fadroma.tech) ([@fadroma/schema 1.1.0](https://www.npmjs.com/package/@fadroma/schema)) from `okp4-dataverse.json` (`f38b5aafa47fb333`)*
+*Rendered by [Fadroma](https://fadroma.tech) ([@fadroma/schema 1.1.0](https://www.npmjs.com/package/@fadroma/schema)) from `okp4-dataverse.json` (`30443a4cdcde9c27`)*
 ````


### PR DESCRIPTION
Implements the storage of credentials submitted through the `SubmitClaims` exec message into the `cognitarium`.

## Overview

The `registrar` mod has been introduced in the dataverse contract to carry all the logic related to the management of claims in the triple store.

The `DataverseCredential` structure comes reflect the format of a credential stored in the `cognitarium`. It can be obtained from a `VerifiableCredential` et can be serialised in RDF to be inserted in the triple store. As a first step in this PR, only a single verifiable credential can be submitted, containing a single claim.

The `ClaimRegistrar` comes to take care of all the logic specific to the management of claims, it allows for the moment to submit a claim, ensuring its unicity. It results in a wasm message corresponding to the cognitarium `InsertData` of the submitted credential.

## Storage schema

The verifiable credential's RDF schema is suitable for the storage in the cognitarium, as it rely on named graph we can't store them in a really independent manner which causes troubles for the revocation. Thus I propose a way through this PR to store them.

In order to enhance the performances when querying credentials only a subset of information is kept, and for the same reason there is a limit of only one claim and subject per credential. The credentials are stored using as subject the credential id, here are the attached predicates:
- `<dataverse:credential#submitterAddress>`: the bech32 address who sent the original transaction;
- `<dataverse:credential#issuer>`: the issuer of the credential;
- `<dataverse:credential#type>`: the credential type (limited to one matching the claim);
- `<dataverse:credential#validFrom>`: the issuance date of the credential;
- `<dataverse:credential#validUntil>`: optional, the expiration date of the credential;
- `<dataverse:credential#subject>`: the subject concerned by the claim;
- `<dataverse:credential#claim>`: the claim, being a blank node pointing to it;

### Example

Taking the below verifiable credential:
```json
{
  "@context": [
    "https://www.w3.org/2018/credentials/v1",
    "https://w3id.org/okp4/ontology/vnext/schema/credential/digital-service/description/"
  ],
  "type": ["VerifiableCredential", "DigitalServiceDescriptionCredential"],
  "id": "https://w3id.org/okp4/ontology/vnext/schema/credential/digital-service/description/72cab400-5bd6-4eb4-8605-a5ee8c1a45c9",
  "issuanceDate": "2024-01-22T09:28:43.475304+01:00",
  "issuer": {
    "id": "did:key:zQ3shs7auhJSmVJpiUbQWco6bxxEhSqWnVEPvaBHBRvBKw6Q3",
    "name": "OKP4"
  },
  "credentialSubject": {
    "hasCategory": "https://w3id.org/okp4/ontology/vnext/thesaurus/digital-service-category/Storage",
    "hasDescription": "IPFS is a decentralized protocol designed to facilitate the storage, sharing, and retrieval of files on a global scale",
    "hasPublisher": "IPFS",
    "hasTag": ["Storage", "Peer-to-peer", "Cloud"],
    "hasTitle": "IPFS",
    "hasWebpage": "https://docs.ipfs.tech/",
    "id": "did:key:zQ3shhb4SvzBRLbBonsvKb3WX6WoDeKWHpsXXXMhAJETqXAfB",
    "type": "DigitalServiceDescriptionCredential"
  }
}
```

The inserted triples in the cognitarium would be:
```
<http://example.okp4.network/credentials/12345> <dataverse:credential#submitterAddress> "okp4..." .
<http://example.okp4.network/credentials/12345> <dataverse:credential#issuer> <did:key:z6MkpwdnLPAm4apwcrRYQ6fZ3rAcqjLZR4AMk14vimfnozqY> .
<http://example.okp4.network/credentials/12345> <dataverse:credential#type> <https://example.org/examples#AlumniCredential> .
<http://example.okp4.network/credentials/12345> <dataverse:credential#validFrom> "2010-01-01T00:00:00Z"^^<http://www.w3.org/2001/XMLSchema#dateTime> .
<http://example.okp4.network/credentials/12345> <dataverse:credential#validUntil> "2020-01-01T00:00:00Z"^^<http://www.w3.org/2001/XMLSchema#dateTime> .
<http://example.okp4.network/credentials/12345> <dataverse:credential#subject> <did:key:z6MkpwdnLPAm4apwcrRYQ6fZ3rAcqjLZR4AMk14vimfnozqY> .
<http://example.okp4.network/credentials/12345> <dataverse:credential#claim> _c0 .
_c0 <http://schema.org/alumniOf> <did:key:zQ3shofi77hSewXdJWj5VsdS5spLrY5EZevwWN1t5adqBM8vM> .
```

### Caveats

The blank node pointing to the claim is currently hard coded to `c0`, it brings potential security issues when using it at submission, it allows to attached other triples to it. This concern will be addressed in the next steps.

## Events

The `SubmitClaims` execute message now provide information attributes in the response:
- `action`: `submit_claims`;
- `credential`: the verifiable credential `id`;
- `subject`: the credential's subject `id`;
- `type`: the type of credential;

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

## Summary by CodeRabbit

- **New Features**
	- Introduced new functionalities for submitting and managing claims within the dataverse, including credential verification and claim submission.
	- Support for cryptographic proofs (`Ed25519Signature2020`, `EcdsaSecp256k1Signature2019`, `DataIntegrity`) in credential submissions.
	- Added the ability to serialize Dataverse credentials into RDF format for storage and retrieval.
	- Implemented a `ClaimRegistrar` for managing claims, including submission and revocation processes.
- **Refactor**
	- Updated function signatures in the `CryptoSuite` to improve code efficiency and readability.
	- Changed visibility and structure of several modules and data types to better align with project architecture.
- **Bug Fixes**
	- Removed obsolete error variant `MissingProof` from `InvalidCredentialError`.
- **Documentation**
	- Updated documentation to reflect the transition from Verifiable Presentations to Verifiable Credentials and detailed requirements for claims submission.
- **Tests**
	- Added comprehensive tests for new functionalities, including credential verification, claim submission, and RDF serialization.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->