### PR TITLE
fix(cognitarium): avoid error on not found ns at plan building

### DIFF
--- a/contracts/okp4-cognitarium/src/querier/engine.rs
+++ b/contracts/okp4-cognitarium/src/querier/engine.rs
@@ -77,6 +77,7 @@ impl<'a> QueryEngine<'a> {
                     object.clone(),
                 ))
             }),
+            QueryNode::Noop { .. } => Rc::new(|_| Box::new(iter::empty())),
             QueryNode::CartesianProductJoin { left, right } => {
                 let left = self.eval_node(*left);
                 let right = self.eval_node(*right);

--- a/contracts/okp4-cognitarium/src/querier/plan.rs
+++ b/contracts/okp4-cognitarium/src/querier/plan.rs
@@ -37,6 +37,11 @@ pub enum QueryNode {
         object: PatternValue<Object>,
     },
 
+    /// Results in no solutions, this special node is used when we know before plan execution that a node
+    /// will end up with no possible solutions. For example, using a triple pattern filtering with a constant
+    /// named node containing a non-existing namespace.
+    Noop { bound_variables: Vec<usize> },
+
     /// Join two nodes by applying the cartesian product of the nodes variables.
     ///
     /// This should be used when the nodes doesn't have variables in common, and can be seen as a
@@ -76,6 +81,9 @@ impl QueryNode {
                 subject.lookup_bound_variable(callback);
                 predicate.lookup_bound_variable(callback);
                 object.lookup_bound_variable(callback);
+            }
+            QueryNode::Noop { bound_variables } => {
+                bound_variables.iter().for_each(|v| callback(*v));
             }
             QueryNode::CartesianProductJoin { left, right }
             | QueryNode::ForLoopJoin { left, right } => {

--- a/contracts/okp4-cognitarium/src/state/namespaces.rs
+++ b/contracts/okp4-cognitarium/src/state/namespaces.rs
@@ -132,6 +132,10 @@ impl NamespaceResolver {
             None => Err(StdError::not_found("Namespace")),
         }
     }
+
+    pub fn is_ns_not_found_error(err: &StdError) -> bool {
+        matches!(err, StdError::NotFound { kind, .. } if kind == "Namespace")
+    }
 }
 
 impl Default for NamespaceResolver {


### PR DESCRIPTION
Avoid erroring when querying with parameters references non existing namespaces.

## Context

When a query contains a reference, as a constant in a triple pattern, to a non existing IRI namespace the query plan fail to build and this results as en error. Which from a client perspective should results in a success with no solutions.

## Proposed solution

I propose through this PR to solve this specific case by introducing a new type of query node in a query plan, the `Noop`. Its usage is only destined to represent a part of a query which we know, before execution that it'll results in no solution, which is the case for triple patterns referencing non existing IRI namespaces.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
	- Introduced a new handling mechanism for queries without immediate solutions, improving processing efficiency.
- **Enhancements**
	- Refined the way triple patterns are constructed and handled, enhancing query flexibility and accuracy.
- **Bug Fixes**
	- Added error handling for "Namespace not found" scenarios, improving system reliability and user experience.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->