### PR TITLE
build: enable only cw 1.2 features to maximize chain compatibility

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -3,7 +3,7 @@ members = ["contracts/*", "packages/*"]
 
 [workspace.dependencies]
 cosmwasm-schema = "1.5.3"
-cosmwasm-std = { version = "1.5.3", features = ["cosmwasm_1_4"] }
+cosmwasm-std = { version = "1.5.3", features = ["cosmwasm_1_2"] }
 cosmwasm-storage = "1.5.2"
 cw-multi-test = "0.20.0"
 cw-storage-plus = "1.2.0"


### PR DESCRIPTION
Allow a better compatibility with CosmWasm enabled chains by enabling only used `cosmwasm-std` features.