### PR TITLE
Feat/dataverse eddsa2018 proof

### DIFF
--- a/contracts/okp4-dataverse/src/credential/vc.rs
+++ b/contracts/okp4-dataverse/src/credential/vc.rs
@@ -82,7 +82,7 @@ impl<'a> VerifiableCredential<'a> {
             deps,
             self.unsecured_document.as_ref(),
             proof.options(),
-            proof.signature(),
+            proof.proof_material(),
             proof.pub_key(),
         )
     }

--- a/contracts/okp4-dataverse/src/credential/vc.rs
+++ b/contracts/okp4-dataverse/src/credential/vc.rs
@@ -369,6 +369,7 @@ mod test {
     #[test]
     fn vc_verify() {
         let cases = vec![
+            "vc-eddsa-2018-ok.nq",
             "vc-eddsa-2020-ok.nq",
             "vc-ecdsa-2019-ok.nq",
             "vc-di-ed-ok.nq",

--- a/contracts/okp4-dataverse/src/msg.rs
+++ b/contracts/okp4-dataverse/src/msg.rs
@@ -47,6 +47,8 @@ pub enum ExecuteMsg {
     ///
     /// #### Supported cryptographic proofs
     ///
+    /// - `Ed25519Signature2018`
+    ///
     /// - `Ed25519Signature2020`
     ///
     /// - `EcdsaSecp256k1Signature2019`

--- a/contracts/okp4-dataverse/testdata/vc-eddsa-2018-ok.nq
+++ b/contracts/okp4-dataverse/testdata/vc-eddsa-2018-ok.nq
@@ -1,0 +1,10 @@
+<http://example.edu/credentials/58473> <http://www.w3.org/1999/02/22-rdf-syntax-ns#type> <https://www.w3.org/2018/credentials#VerifiableCredential> .
+<http://example.edu/credentials/58473> <https://w3id.org/security#proof> _:b0 .
+<http://example.edu/credentials/58473> <https://www.w3.org/2018/credentials#credentialSubject> <did:key:zQ3shofi77hSewXdJWj5VsdS5spLrY5EZevwWN1t5adqBM8vM> .
+<http://example.edu/credentials/58473> <https://www.w3.org/2018/credentials#issuanceDate> "2023-05-01T06:09:10Z"^^<http://www.w3.org/2001/XMLSchema#dateTime> .
+<http://example.edu/credentials/58473> <https://www.w3.org/2018/credentials#issuer> <did:key:z6MkpwdnLPAm4apwcrRYQ6fZ3rAcqjLZR4AMk14vimfnozqY> .
+_:b1 <http://purl.org/dc/terms/created> "2024-02-21T20:17:42.150598Z"^^<http://www.w3.org/2001/XMLSchema#dateTime> _:b0 .
+_:b1 <http://www.w3.org/1999/02/22-rdf-syntax-ns#type> <https://w3id.org/security#Ed25519Signature2018> _:b0 .
+_:b1 <https://w3id.org/security#jws> "eyJhbGciOiJFZERTQSIsImNyaXQiOlsiYjY0Il0sImI2NCI6ZmFsc2V9..5YzyqmQp1yPAea1WgKYzXOWTdYiDJO5iZs3bjxnSCzJYZS-ToIIqL4T47Ni7zZpc8S968vPKdCZcQzkoNnIIDw" _:b0 .
+_:b1 <https://w3id.org/security#proofPurpose> <https://w3id.org/security#assertionMethod> _:b0 .
+_:b1 <https://w3id.org/security#verificationMethod> <did:key:z6MkpwdnLPAm4apwcrRYQ6fZ3rAcqjLZR4AMk14vimfnozqY#z6MkpwdnLPAm4apwcrRYQ6fZ3rAcqjLZR4AMk14vimfnozqY> _:b0 .

--- a/docs/okp4-dataverse.md
+++ b/docs/okp4-dataverse.md
@@ -88,6 +88,8 @@ To maintain integrity and coherence in the dataverse, several preconditions are 
 
 #### Supported cryptographic proofs
 
+- `Ed25519Signature2018`
+
 - `Ed25519Signature2020`
 
 - `EcdsaSecp256k1Signature2019`
@@ -221,5 +223,5 @@ let b = Uint64::from(70u32); assert_eq!(b.u64(), 70); ```
 
 ---
 
-*Rendered by [Fadroma](https://fadroma.tech) ([@fadroma/schema 1.1.0](https://www.npmjs.com/package/@fadroma/schema)) from `okp4-dataverse.json` (`30443a4cdcde9c27`)*
+*Rendered by [Fadroma](https://fadroma.tech) ([@fadroma/schema 1.1.0](https://www.npmjs.com/package/@fadroma/schema)) from `okp4-dataverse.json` (`cf6cd863236d7567`)*
 ````


### PR DESCRIPTION
This PR brings the support of [Ed25519Signature2018](https://w3c-ccg.github.io/lds-ed25519-2018) verifiable credential cryptographic proof type.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
	- Introduced support for `Ed25519Signature2018` cryptographic proof, enhancing security and verification processes.
	- Added a new `ProofMaterial` enum to handle various proof materials like `Signature` and `Jws` for verification.
- **Refactor**
	- Modified the verification logic to accommodate different types of proof materials.
- **Tests**
	- Included a new test case to validate the creation and verification of Verifiable Credentials using the EdDSA signature scheme.
- **Documentation**
	- Updated documentation to reflect support for `Ed25519Signature2018` cryptographic proof and detailed the verification enhancements.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->