### PR TITLE
Fix/blank node query

### DIFF
--- a/contracts/okp4-cognitarium/src/contract.rs
+++ b/contracts/okp4-cognitarium/src/contract.rs
@@ -378,7 +378,7 @@ mod tests {
     use super::*;
     use crate::error::StoreError;
     use crate::msg::ExecuteMsg::{DeleteData, InsertData};
-    use crate::msg::Node::NamedNode;
+    use crate::msg::Node::{BlankNode, NamedNode};
     use crate::msg::SimpleWhereCondition::TriplePattern;
     use crate::msg::IRI::{Full, Prefixed};
     use crate::msg::{
@@ -489,7 +489,7 @@ mod tests {
                 res.unwrap().attributes,
                 vec![
                     Attribute::new("action", "insert"),
-                    Attribute::new("triple_count", "40")
+                    Attribute::new("triple_count", "40"),
                 ]
             );
 
@@ -512,7 +512,7 @@ mod tests {
                 namespaces()
                     .load(
                         &deps.storage,
-                        "https://ontology.okp4.space/dataverse/dataspace/".to_string()
+                        "https://ontology.okp4.space/dataverse/dataspace/".to_string(),
                     )
                     .unwrap(),
                 Namespace {
@@ -529,35 +529,35 @@ mod tests {
                             Object::Named(Node {
                                 namespace: 4u128,
                                 value: "0x04d1f1b8f8a7a28f9a5a254c326a963a22f5a5b5d5f5e5d5c5b5a5958575655"
-                                    .to_string()
+                                    .to_string(),
                             }).as_hash()
-                            .as_bytes(),
+                                .as_bytes(),
                             Node {
                                 namespace: 3u128,
-                                value: "hasRegistrar".to_string()
+                                value: "hasRegistrar".to_string(),
                             }
-                            .key(),
+                                .key(),
                             Subject::Named(Node {
                                 namespace: 0u128,
-                                value: "97ff7e16-c08d-47be-8475-211016c82e33".to_string()
+                                value: "97ff7e16-c08d-47be-8475-211016c82e33".to_string(),
                             })
-                            .key()
-                        )
+                                .key()
+                        ),
                     )
                     .unwrap(),
                 Triple {
                     object: Object::Named(Node {
                         namespace: 4u128,
                         value: "0x04d1f1b8f8a7a28f9a5a254c326a963a22f5a5b5d5f5e5d5c5b5a5958575655"
-                            .to_string()
+                            .to_string(),
                     }),
                     predicate: Node {
                         namespace: 3u128,
-                        value: "hasRegistrar".to_string()
+                        value: "hasRegistrar".to_string(),
                     },
                     subject: Subject::Named(Node {
                         namespace: 0u128,
-                        value: "97ff7e16-c08d-47be-8475-211016c82e33".to_string()
+                        value: "97ff7e16-c08d-47be-8475-211016c82e33".to_string(),
                     }),
                 }
             )
@@ -603,7 +603,7 @@ mod tests {
             res.unwrap().attributes,
             vec![
                 Attribute::new("action", "insert"),
-                Attribute::new("triple_count", "0")
+                Attribute::new("triple_count", "0"),
             ]
         );
 
@@ -963,7 +963,7 @@ mod tests {
                 res.unwrap().attributes,
                 vec![
                     Attribute::new("action", "delete"),
-                    Attribute::new("triple_count", case.1.to_string())
+                    Attribute::new("triple_count", case.1.to_string()),
                 ]
             );
 
@@ -1136,7 +1136,7 @@ mod tests {
                     triple_count: 1u128.into(),
                     namespace_count: 2u128.into(),
                     byte_size: 3u128.into(),
-                }
+                },
             }
         );
     }
@@ -1246,7 +1246,7 @@ mod tests {
                                         datatype: None,
                                     }
                                 )
-                            ])
+                            ]),
                         ],
                     },
                 },
@@ -1255,35 +1255,35 @@ mod tests {
                 SelectQuery {
                     prefixes: vec![Prefix { prefix: "core".to_string(), namespace: "https://ontology.okp4.space/core/".to_string() }],
                     select: vec![
-                     SelectItem::Variable("a".to_string()),
+                        SelectItem::Variable("a".to_string()),
                     ],
                     r#where: vec![WhereCondition::Simple(TriplePattern(
-                     msg::TriplePattern {
-                         subject: VarOrNode::Variable("a".to_string()),
-                         predicate: VarOrNode::Node(NamedNode(Prefixed(
-                             "core:hasDescription".to_string(),
-                         ))),
-                         object: VarOrNodeOrLiteral::Literal(Literal::LanguageTaggedString { value: "A test Dataset.".to_string(), language: "en".to_string() }),
-                     },
+                        msg::TriplePattern {
+                            subject: VarOrNode::Variable("a".to_string()),
+                            predicate: VarOrNode::Node(NamedNode(Prefixed(
+                                "core:hasDescription".to_string(),
+                            ))),
+                            object: VarOrNodeOrLiteral::Literal(Literal::LanguageTaggedString { value: "A test Dataset.".to_string(), language: "en".to_string() }),
+                        },
                     ))],
                     limit: None,
                 },
                 SelectResponse {
-                 head: Head {
-                     vars: vec!["a".to_string()],
-                 },
-                 results: Results {
-                     bindings: vec![
-                         BTreeMap::from([
-                             (
-                                 "a".to_string(),
-                                 Value::URI {
-                                     value: Full("https://ontology.okp4.space/dataverse/dataset/metadata/d1615703-4ee1-4e2f-997e-15aecf1eea4e".to_string())
-                                 }
-                             ),
-                         ])
-                     ],
-                 },
+                    head: Head {
+                        vars: vec!["a".to_string()],
+                    },
+                    results: Results {
+                        bindings: vec![
+                            BTreeMap::from([
+                                (
+                                    "a".to_string(),
+                                    Value::URI {
+                                        value: Full("https://ontology.okp4.space/dataverse/dataset/metadata/d1615703-4ee1-4e2f-997e-15aecf1eea4e".to_string())
+                                    }
+                                ),
+                            ])
+                        ],
+                    },
                 },
             ),
             (
@@ -1318,7 +1318,7 @@ mod tests {
                         ],
                     },
                 },
-            )
+            ),
         ];
 
         let mut deps = mock_dependencies();
@@ -1339,6 +1339,227 @@ mod tests {
             InsertData {
                 format: Some(DataFormat::RDFXml),
                 data: read_test_data("sample.rdf.xml"),
+            },
+        )
+        .unwrap();
+
+        for (q, expected) in cases {
+            let res = query(deps.as_ref(), mock_env(), QueryMsg::Select { query: q });
+            assert!(res.is_ok());
+
+            let result = from_json::<SelectResponse>(&res.unwrap()).unwrap();
+            assert_eq!(result, expected);
+        }
+    }
+
+    #[test]
+    fn proper_select_blank_nodes() {
+        let cases = vec![
+            (
+                SelectQuery {
+                    prefixes: vec![Prefix { prefix: "core".to_string(), namespace: "https://ontology.okp4.space/core/".to_string() }],
+                    select: vec![SelectItem::Variable("a".to_string()), SelectItem::Variable("b".to_string())],
+                    r#where: vec![
+                        WhereCondition::Simple(TriplePattern(
+                            msg::TriplePattern {
+                                subject: VarOrNode::Variable("a".to_string()),
+                                predicate: VarOrNode::Node(NamedNode(Prefixed(
+                                    "core:hasTemporalCoverage".to_string(),
+                                ))),
+                                object: VarOrNodeOrLiteral::Node(BlankNode("a".to_string())),
+                            },
+                        )),
+                        WhereCondition::Simple(TriplePattern(
+                            msg::TriplePattern {
+                                subject: VarOrNode::Node(BlankNode("a".to_string())),
+                                predicate: VarOrNode::Node(NamedNode(Prefixed(
+                                    "core:hasStartDate".to_string(),
+                                ))),
+                                object: VarOrNodeOrLiteral::Variable("b".to_string()),
+                            },
+                        ))],
+                    limit: None,
+                },
+                SelectResponse {
+                    head: Head { vars: vec!["a".to_string(), "b".to_string()] },
+                    results: Results {
+                        bindings: vec![
+                            BTreeMap::from([
+                                (
+                                    "a".to_string(),
+                                    Value::URI {
+                                        value: Full("https://ontology.okp4.space/dataverse/dataset/metadata/80b1f84e-86dc-4730-b54f-701ad9b1888a".to_string())
+                                    }
+                                ),
+                                (
+                                    "b".to_string(),
+                                    Value::Literal {
+                                        value: "2022-01-01T00:00:00+00:00".to_string(),
+                                        lang: None,
+                                        datatype: Some(Full("http://www.w3.org/2001/XMLSchema#dateTime".to_string())),
+                                    }
+                                )
+                            ])
+                        ],
+                    },
+                },
+            ),
+            (
+                SelectQuery {
+                    prefixes: vec![Prefix { prefix: "core".to_string(), namespace: "https://ontology.okp4.space/core/".to_string() }],
+                    select: vec![SelectItem::Variable("a".to_string()), SelectItem::Variable("b".to_string())],
+                    r#where: vec![
+                        WhereCondition::Simple(TriplePattern(
+                            msg::TriplePattern {
+                                subject: VarOrNode::Variable("a".to_string()),
+                                predicate: VarOrNode::Node(NamedNode(Prefixed(
+                                    "core:hasTemporalCoverage".to_string(),
+                                ))),
+                                object: VarOrNodeOrLiteral::Variable("blank".to_string()),
+                            },
+                        )),
+                        WhereCondition::Simple(TriplePattern(
+                            msg::TriplePattern {
+                                subject: VarOrNode::Variable("blank".to_string()),
+                                predicate: VarOrNode::Node(NamedNode(Prefixed(
+                                    "core:hasStartDate".to_string(),
+                                ))),
+                                object: VarOrNodeOrLiteral::Variable("b".to_string()),
+                            },
+                        ))],
+                    limit: None,
+                },
+                SelectResponse {
+                    head: Head { vars: vec!["a".to_string(), "b".to_string()] },
+                    results: Results {
+                        bindings: vec![
+                            BTreeMap::from([
+                                (
+                                    "a".to_string(),
+                                    Value::URI {
+                                        value: Full("https://ontology.okp4.space/dataverse/dataset/metadata/80b1f84e-86dc-4730-b54f-701ad9b1888a".to_string())
+                                    }
+                                ),
+                                (
+                                    "b".to_string(),
+                                    Value::Literal {
+                                        value: "2022-01-01T00:00:00+00:00".to_string(),
+                                        lang: None,
+                                        datatype: Some(Full("http://www.w3.org/2001/XMLSchema#dateTime".to_string())),
+                                    }
+                                )
+                            ])
+                        ],
+                    },
+                },
+            ),
+            (
+                SelectQuery {
+                    prefixes: vec![Prefix { prefix: "core".to_string(), namespace: "https://ontology.okp4.space/core/".to_string() }],
+                    select: vec![SelectItem::Variable("a".to_string()), SelectItem::Variable("b".to_string())],
+                    r#where: vec![
+                        WhereCondition::Simple(TriplePattern(
+                            msg::TriplePattern {
+                                subject: VarOrNode::Variable("a".to_string()),
+                                predicate: VarOrNode::Node(NamedNode(Prefixed(
+                                    "core:hasTemporalCoverage".to_string(),
+                                ))),
+                                object: VarOrNodeOrLiteral::Node(BlankNode("blank1".to_string())),
+                            },
+                        )),
+                        WhereCondition::Simple(TriplePattern(
+                            msg::TriplePattern {
+                                subject: VarOrNode::Node(BlankNode("blank2".to_string())),
+                                predicate: VarOrNode::Node(NamedNode(Prefixed(
+                                    "core:hasInformation".to_string(),
+                                ))),
+                                object: VarOrNodeOrLiteral::Variable("b".to_string()),
+                            },
+                        ))],
+                    limit: None,
+                },
+                SelectResponse {
+                    head: Head { vars: vec!["a".to_string(), "b".to_string()] },
+                    results: Results {
+                        bindings: vec![
+                            BTreeMap::from([
+                                (
+                                    "a".to_string(),
+                                    Value::URI {
+                                        value: Full("https://ontology.okp4.space/dataverse/dataset/metadata/80b1f84e-86dc-4730-b54f-701ad9b1888a".to_string())
+                                    }
+                                ),
+                                (
+                                    "b".to_string(),
+                                    Value::Literal {
+                                        value: "this is a dataset".to_string(),
+                                        lang: None,
+                                        datatype: None,
+                                    }
+                                )
+                            ])
+                        ],
+                    },
+                },
+            ),
+            (
+                SelectQuery {
+                    prefixes: vec![Prefix { prefix: "core".to_string(), namespace: "https://ontology.okp4.space/core/".to_string() }],
+                    select: vec![SelectItem::Variable("a".to_string()), SelectItem::Variable("b".to_string())],
+                    r#where: vec![
+                        WhereCondition::Simple(TriplePattern(
+                            msg::TriplePattern {
+                                subject: VarOrNode::Variable("a".to_string()),
+                                predicate: VarOrNode::Node(NamedNode(Prefixed(
+                                    "core:hasTemporalCoverage".to_string(),
+                                ))),
+                                object: VarOrNodeOrLiteral::Variable("b".to_string()),
+                            },
+                        ))],
+                    limit: None,
+                },
+                SelectResponse {
+                    head: Head { vars: vec!["a".to_string(), "b".to_string()] },
+                    results: Results {
+                        bindings: vec![
+                            BTreeMap::from([
+                                (
+                                    "a".to_string(),
+                                    Value::URI {
+                                        value: Full("https://ontology.okp4.space/dataverse/dataset/metadata/80b1f84e-86dc-4730-b54f-701ad9b1888a".to_string())
+                                    }
+                                ),
+                                (
+                                    "b".to_string(),
+                                    Value::BlankNode {
+                                        value: "riog00000001".to_string(),
+                                    }
+                                )
+                            ])
+                        ],
+                    },
+                },
+            ),
+        ];
+
+        let mut deps = mock_dependencies();
+
+        let info = mock_info("owner", &[]);
+        instantiate(
+            deps.as_mut(),
+            mock_env(),
+            info.clone(),
+            InstantiateMsg::default(),
+        )
+        .unwrap();
+
+        execute(
+            deps.as_mut(),
+            mock_env(),
+            info,
+            InsertData {
+                format: Some(DataFormat::Turtle),
+                data: read_test_data("blank-nodes.ttl"),
             },
         )
         .unwrap();
@@ -1457,19 +1678,19 @@ mod tests {
     #[test]
     fn formats_describe() {
         let cases = vec![
-        (
-            QueryMsg::Describe {
-                query: DescribeQuery {
-                    prefixes: vec![],
-                    resource: VarOrNamedNode::NamedNode(Full("https://ontology.okp4.space/dataverse/dataspace/metadata/dcf48417-01c5-4b43-9bc7-49e54c028473".to_string())),
-                    r#where: vec![],
+            (
+                QueryMsg::Describe {
+                    query: DescribeQuery {
+                        prefixes: vec![],
+                        resource: VarOrNamedNode::NamedNode(Full("https://ontology.okp4.space/dataverse/dataspace/metadata/dcf48417-01c5-4b43-9bc7-49e54c028473".to_string())),
+                        r#where: vec![],
+                    },
+                    format: Some(DataFormat::Turtle),
                 },
-                format: Some(DataFormat::Turtle),
-            },
-            DescribeResponse {
-                format: DataFormat::Turtle,
-                data: Binary::from(
-                   "<https://ontology.okp4.space/dataverse/dataspace/metadata/dcf48417-01c5-4b43-9bc7-49e54c028473> <http://www.w3.org/1999/02/22-rdf-syntax-ns#type> <https://ontology.okp4.space/metadata/dataspace/GeneralMetadata> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
+                DescribeResponse {
+                    format: DataFormat::Turtle,
+                    data: Binary::from(
+                        "<https://ontology.okp4.space/dataverse/dataspace/metadata/dcf48417-01c5-4b43-9bc7-49e54c028473> <http://www.w3.org/1999/02/22-rdf-syntax-ns#type> <https://ontology.okp4.space/metadata/dataspace/GeneralMetadata> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
 \t<https://ontology.okp4.space/core/hasTag> \"Test\" , \"OKP4\" ;
 \t<https://ontology.okp4.space/core/hasTitle> \"Data Space de test\"@fr , \"Test Data Space\"@en ;
 \t<https://ontology.okp4.space/core/hasTopic> <https://ontology.okp4.space/thesaurus/topic/Test> ;
@@ -1478,21 +1699,21 @@ mod tests {
 \t<https://ontology.okp4.space/core/hasDescription> \"A test Data Space.\"@en , \"Un Data Space de test.\"@fr .
 \
                 ".to_string().as_bytes().to_vec()),
-            }
-        ),
-        (
-            QueryMsg::Describe {
-                query: DescribeQuery {
-                    prefixes: vec![],
-                    resource: VarOrNamedNode::NamedNode(Full("https://ontology.okp4.space/dataverse/dataspace/metadata/dcf48417-01c5-4b43-9bc7-49e54c028473".to_string())),
-                    r#where: vec![],
+                }
+            ),
+            (
+                QueryMsg::Describe {
+                    query: DescribeQuery {
+                        prefixes: vec![],
+                        resource: VarOrNamedNode::NamedNode(Full("https://ontology.okp4.space/dataverse/dataspace/metadata/dcf48417-01c5-4b43-9bc7-49e54c028473".to_string())),
+                        r#where: vec![],
+                    },
+                    format: Some(DataFormat::RDFXml),
                 },
-                format: Some(DataFormat::RDFXml),
-            },
-            DescribeResponse {
-                format: DataFormat::RDFXml,
-                data: Binary::from(
-                   "<?xml version=\"1.0\" encoding=\"UTF-8\"?><rdf:RDF xmlns:rdf=\"http://www.w3.org/1999/02/22-rdf-syntax-ns#\">\
+                DescribeResponse {
+                    format: DataFormat::RDFXml,
+                    data: Binary::from(
+                        "<?xml version=\"1.0\" encoding=\"UTF-8\"?><rdf:RDF xmlns:rdf=\"http://www.w3.org/1999/02/22-rdf-syntax-ns#\">\
 <rdf:Description rdf:about=\"https://ontology.okp4.space/dataverse/dataspace/metadata/dcf48417-01c5-4b43-9bc7-49e54c028473\">\
 <type xmlns=\"http://www.w3.org/1999/02/22-rdf-syntax-ns#\" rdf:resource=\"https://ontology.okp4.space/metadata/dataspace/GeneralMetadata\"/>\
 <type xmlns=\"http://www.w3.org/1999/02/22-rdf-syntax-ns#\" rdf:resource=\"http://www.w3.org/2002/07/owl#NamedIndividual\"/>\
@@ -1507,29 +1728,29 @@ mod tests {
 </rdf:RDF>\
 \
                 ".to_string().as_bytes().to_vec()),
-            }
-        ),
-        (
-            QueryMsg::Describe {
-                query: DescribeQuery {
-                    prefixes: vec![],
-                    resource: VarOrNamedNode::NamedNode(Full("https://ontology.okp4.space/dataverse/dataspace/metadata/dcf48417-01c5-4b43-9bc7-49e54c028473".to_string())),
-                    r#where: vec![WhereCondition::Simple(TriplePattern(
-                        msg::TriplePattern {
-                            subject: VarOrNode::Variable("a".to_string()),
-                            predicate: VarOrNode::Node(NamedNode(Full(
-                                "https://ontology.okp4.space/core/hasDescription".to_string(),
-                            ))),
-                            object: VarOrNodeOrLiteral::Variable("b".to_string()),
-                        },
-                    ))],
+                }
+            ),
+            (
+                QueryMsg::Describe {
+                    query: DescribeQuery {
+                        prefixes: vec![],
+                        resource: VarOrNamedNode::NamedNode(Full("https://ontology.okp4.space/dataverse/dataspace/metadata/dcf48417-01c5-4b43-9bc7-49e54c028473".to_string())),
+                        r#where: vec![WhereCondition::Simple(TriplePattern(
+                            msg::TriplePattern {
+                                subject: VarOrNode::Variable("a".to_string()),
+                                predicate: VarOrNode::Node(NamedNode(Full(
+                                    "https://ontology.okp4.space/core/hasDescription".to_string(),
+                                ))),
+                                object: VarOrNodeOrLiteral::Variable("b".to_string()),
+                            },
+                        ))],
+                    },
+                    format: Some(DataFormat::NTriples),
                 },
-                format: Some(DataFormat::NTriples),
-            },
-            DescribeResponse {
-                format: DataFormat::NTriples,
-                data: Binary::from(
-                   "<https://ontology.okp4.space/dataverse/dataspace/metadata/dcf48417-01c5-4b43-9bc7-49e54c028473> <http://www.w3.org/1999/02/22-rdf-syntax-ns#type> <https://ontology.okp4.space/metadata/dataspace/GeneralMetadata> .
+                DescribeResponse {
+                    format: DataFormat::NTriples,
+                    data: Binary::from(
+                        "<https://ontology.okp4.space/dataverse/dataspace/metadata/dcf48417-01c5-4b43-9bc7-49e54c028473> <http://www.w3.org/1999/02/22-rdf-syntax-ns#type> <https://ontology.okp4.space/metadata/dataspace/GeneralMetadata> .
 <https://ontology.okp4.space/dataverse/dataspace/metadata/dcf48417-01c5-4b43-9bc7-49e54c028473> <http://www.w3.org/1999/02/22-rdf-syntax-ns#type> <http://www.w3.org/2002/07/owl#NamedIndividual> .
 <https://ontology.okp4.space/dataverse/dataspace/metadata/dcf48417-01c5-4b43-9bc7-49e54c028473> <https://ontology.okp4.space/core/hasTag> \"Test\" .
 <https://ontology.okp4.space/dataverse/dataspace/metadata/dcf48417-01c5-4b43-9bc7-49e54c028473> <https://ontology.okp4.space/core/hasTag> \"OKP4\" .
@@ -1542,21 +1763,21 @@ mod tests {
 <https://ontology.okp4.space/dataverse/dataspace/metadata/dcf48417-01c5-4b43-9bc7-49e54c028473> <https://ontology.okp4.space/core/hasDescription> \"Un Data Space de test.\"@fr .
 \
                 ".to_string().as_bytes().to_vec()),
-            }
-        ),
-        (
-            QueryMsg::Describe {
-                query: DescribeQuery {
-                    prefixes: vec![],
-                    resource: VarOrNamedNode::NamedNode(Full("https://ontology.okp4.space/dataverse/dataspace/metadata/dcf48417-01c5-4b43-9bc7-49e54c028473".to_string())),
-                    r#where: vec![],
+                }
+            ),
+            (
+                QueryMsg::Describe {
+                    query: DescribeQuery {
+                        prefixes: vec![],
+                        resource: VarOrNamedNode::NamedNode(Full("https://ontology.okp4.space/dataverse/dataspace/metadata/dcf48417-01c5-4b43-9bc7-49e54c028473".to_string())),
+                        r#where: vec![],
+                    },
+                    format: Some(DataFormat::NQuads),
                 },
-                format: Some(DataFormat::NQuads),
-            },
-            DescribeResponse {
-                format: DataFormat::NQuads,
-                data: Binary::from(
-                   "<https://ontology.okp4.space/dataverse/dataspace/metadata/dcf48417-01c5-4b43-9bc7-49e54c028473> <http://www.w3.org/1999/02/22-rdf-syntax-ns#type> <https://ontology.okp4.space/metadata/dataspace/GeneralMetadata> .
+                DescribeResponse {
+                    format: DataFormat::NQuads,
+                    data: Binary::from(
+                        "<https://ontology.okp4.space/dataverse/dataspace/metadata/dcf48417-01c5-4b43-9bc7-49e54c028473> <http://www.w3.org/1999/02/22-rdf-syntax-ns#type> <https://ontology.okp4.space/metadata/dataspace/GeneralMetadata> .
 <https://ontology.okp4.space/dataverse/dataspace/metadata/dcf48417-01c5-4b43-9bc7-49e54c028473> <http://www.w3.org/1999/02/22-rdf-syntax-ns#type> <http://www.w3.org/2002/07/owl#NamedIndividual> .
 <https://ontology.okp4.space/dataverse/dataspace/metadata/dcf48417-01c5-4b43-9bc7-49e54c028473> <https://ontology.okp4.space/core/hasTag> \"Test\" .
 <https://ontology.okp4.space/dataverse/dataspace/metadata/dcf48417-01c5-4b43-9bc7-49e54c028473> <https://ontology.okp4.space/core/hasTag> \"OKP4\" .
@@ -1569,9 +1790,9 @@ mod tests {
 <https://ontology.okp4.space/dataverse/dataspace/metadata/dcf48417-01c5-4b43-9bc7-49e54c028473> <https://ontology.okp4.space/core/hasDescription> \"Un Data Space de test.\"@fr .
 \
                 ".to_string().as_bytes().to_vec()),
-            }
-        ),
-    ];
+                }
+            ),
+        ];
 
         let mut deps = mock_dependencies();
 
@@ -1613,24 +1834,24 @@ mod tests {
     #[test]
     fn prefixes_describe() {
         let cases = vec![
-        (
-            QueryMsg::Describe {
-                query: DescribeQuery {
-                    prefixes: vec![
-                        Prefix {
-                            prefix: "metadata".to_string(),
-                            namespace: "https://ontology.okp4.space/dataverse/dataspace/metadata/".to_string(),
-                        },
-                    ],
-                    resource: VarOrNamedNode::NamedNode(Prefixed("metadata:dcf48417-01c5-4b43-9bc7-49e54c028473".to_string())),
-                    r#where: vec![],
+            (
+                QueryMsg::Describe {
+                    query: DescribeQuery {
+                        prefixes: vec![
+                            Prefix {
+                                prefix: "metadata".to_string(),
+                                namespace: "https://ontology.okp4.space/dataverse/dataspace/metadata/".to_string(),
+                            },
+                        ],
+                        resource: VarOrNamedNode::NamedNode(Prefixed("metadata:dcf48417-01c5-4b43-9bc7-49e54c028473".to_string())),
+                        r#where: vec![],
+                    },
+                    format: Some(DataFormat::Turtle),
                 },
-                format: Some(DataFormat::Turtle),
-            },
-            DescribeResponse {
-                format: DataFormat::Turtle,
-                data: Binary::from(
-                   "<https://ontology.okp4.space/dataverse/dataspace/metadata/dcf48417-01c5-4b43-9bc7-49e54c028473> <http://www.w3.org/1999/02/22-rdf-syntax-ns#type> <https://ontology.okp4.space/metadata/dataspace/GeneralMetadata> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
+                DescribeResponse {
+                    format: DataFormat::Turtle,
+                    data: Binary::from(
+                        "<https://ontology.okp4.space/dataverse/dataspace/metadata/dcf48417-01c5-4b43-9bc7-49e54c028473> <http://www.w3.org/1999/02/22-rdf-syntax-ns#type> <https://ontology.okp4.space/metadata/dataspace/GeneralMetadata> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
 \t<https://ontology.okp4.space/core/hasTag> \"Test\" , \"OKP4\" ;
 \t<https://ontology.okp4.space/core/hasTitle> \"Data Space de test\"@fr , \"Test Data Space\"@en ;
 \t<https://ontology.okp4.space/core/hasTopic> <https://ontology.okp4.space/thesaurus/topic/Test> ;
@@ -1639,8 +1860,8 @@ mod tests {
 \t<https://ontology.okp4.space/core/hasDescription> \"A test Data Space.\"@en , \"Un Data Space de test.\"@fr .
 \
                 ".to_string().as_bytes().to_vec()),
-            }
-        ),
+                }
+            ),
         ];
 
         let mut deps = mock_dependencies();
@@ -1683,29 +1904,29 @@ mod tests {
     #[test]
     fn variable_describe() {
         let cases = vec![
-        (
-            QueryMsg::Describe {
-                query: DescribeQuery {
-                    prefixes: vec![Prefix { prefix: "core".to_string(), namespace: "https://ontology.okp4.space/core/".to_string() }],
-                    resource: VarOrNamedNode::Variable("a".to_string()),
-                    r#where: vec![WhereCondition::Simple(TriplePattern(
-                        msg::TriplePattern {
-                            subject: VarOrNode::Variable("a".to_string()),
-                            predicate: VarOrNode::Node(NamedNode(Prefixed(
-                                "core:hasDescription".to_string(),
-                            ))),
-                            object: VarOrNodeOrLiteral::Literal(Literal::LanguageTaggedString { value: "A test Dataset.".to_string(), language: "en".to_string() }),
-                        },
-                       ))],
+            (
+                QueryMsg::Describe {
+                    query: DescribeQuery {
+                        prefixes: vec![Prefix { prefix: "core".to_string(), namespace: "https://ontology.okp4.space/core/".to_string() }],
+                        resource: VarOrNamedNode::Variable("a".to_string()),
+                        r#where: vec![WhereCondition::Simple(TriplePattern(
+                            msg::TriplePattern {
+                                subject: VarOrNode::Variable("a".to_string()),
+                                predicate: VarOrNode::Node(NamedNode(Prefixed(
+                                    "core:hasDescription".to_string(),
+                                ))),
+                                object: VarOrNodeOrLiteral::Literal(Literal::LanguageTaggedString { value: "A test Dataset.".to_string(), language: "en".to_string() }),
+                            },
+                        ))],
+                    },
+                    format: Some(DataFormat::Turtle),
                 },
-                format: Some(DataFormat::Turtle),
-            },
-            DescribeResponse {
-                format: DataFormat::Turtle,
-                data: Binary::from(
-                   "<https://ontology.okp4.space/dataverse/dataset/metadata/d1615703-4ee1-4e2f-997e-15aecf1eea4e> <http://www.w3.org/1999/02/22-rdf-syntax-ns#type> <https://ontology.okp4.space/metadata/dataset/GeneralMetadata> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;\n\t<https://ontology.okp4.space/core/hasTag> \"test\" ;\n\t<https://ontology.okp4.space/core/hasTitle> \"test Dataset\"@en , \"Dataset de test\"@fr ;\n\t<https://ontology.okp4.space/core/hasTopic> <https://ontology.okp4.space/thesaurus/topic/Test> ;\n\t<https://ontology.okp4.space/core/describes> <https://ontology.okp4.space/dataverse/dataset/0ea1fc7a-dd97-4adc-a10e-169c6597bcde> ;\n\t<https://ontology.okp4.space/core/hasFormat> <https://ontology.okp4.space/thesaurus/media-type/application_vndms-excel> ;\n\t<https://ontology.okp4.space/core/hasCreator> \"Me\" ;\n\t<https://ontology.okp4.space/core/hasLicense> <https://ontology.okp4.space/thesaurus/license/LO-FR-1_0> ;\n\t<https://ontology.okp4.space/core/hasPublisher> \"OKP4\" ;\n\t<https://ontology.okp4.space/core/hasDescription> \"Un Dataset de test.\"@fr , \"A test Dataset.\"@en .\n".to_string().as_bytes().to_vec()),
-            }
-        ),
+                DescribeResponse {
+                    format: DataFormat::Turtle,
+                    data: Binary::from(
+                        "<https://ontology.okp4.space/dataverse/dataset/metadata/d1615703-4ee1-4e2f-997e-15aecf1eea4e> <http://www.w3.org/1999/02/22-rdf-syntax-ns#type> <https://ontology.okp4.space/metadata/dataset/GeneralMetadata> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;\n\t<https://ontology.okp4.space/core/hasTag> \"test\" ;\n\t<https://ontology.okp4.space/core/hasTitle> \"test Dataset\"@en , \"Dataset de test\"@fr ;\n\t<https://ontology.okp4.space/core/hasTopic> <https://ontology.okp4.space/thesaurus/topic/Test> ;\n\t<https://ontology.okp4.space/core/describes> <https://ontology.okp4.space/dataverse/dataset/0ea1fc7a-dd97-4adc-a10e-169c6597bcde> ;\n\t<https://ontology.okp4.space/core/hasFormat> <https://ontology.okp4.space/thesaurus/media-type/application_vndms-excel> ;\n\t<https://ontology.okp4.space/core/hasCreator> \"Me\" ;\n\t<https://ontology.okp4.space/core/hasLicense> <https://ontology.okp4.space/thesaurus/license/LO-FR-1_0> ;\n\t<https://ontology.okp4.space/core/hasPublisher> \"OKP4\" ;\n\t<https://ontology.okp4.space/core/hasDescription> \"Un Dataset de test.\"@fr , \"A test Dataset.\"@en .\n".to_string().as_bytes().to_vec()),
+                }
+            ),
         ];
 
         let mut deps = mock_dependencies();
@@ -1748,29 +1969,29 @@ mod tests {
     #[test]
     fn variable_mutiple_resources_describe() {
         let cases = vec![
-        (
-            QueryMsg::Describe {
-                query: DescribeQuery {
-                    prefixes: vec![Prefix { prefix: "core".to_string(), namespace: "https://ontology.okp4.space/core/".to_string() }],
-                    resource: VarOrNamedNode::Variable("a".to_string()),
-                    r#where: vec![WhereCondition::Simple(TriplePattern(
-                        msg::TriplePattern {
-                            subject: VarOrNode::Variable("a".to_string()),
-                            predicate: VarOrNode::Node(NamedNode(Prefixed(
-                                "core:hasPublisher".to_string(),
-                            ))),
-                            object: VarOrNodeOrLiteral::Literal(Literal::Simple("OKP4".to_string())),
-                        },
-                       ))],
+            (
+                QueryMsg::Describe {
+                    query: DescribeQuery {
+                        prefixes: vec![Prefix { prefix: "core".to_string(), namespace: "https://ontology.okp4.space/core/".to_string() }],
+                        resource: VarOrNamedNode::Variable("a".to_string()),
+                        r#where: vec![WhereCondition::Simple(TriplePattern(
+                            msg::TriplePattern {
+                                subject: VarOrNode::Variable("a".to_string()),
+                                predicate: VarOrNode::Node(NamedNode(Prefixed(
+                                    "core:hasPublisher".to_string(),
+                                ))),
+                                object: VarOrNodeOrLiteral::Literal(Literal::Simple("OKP4".to_string())),
+                            },
+                        ))],
+                    },
+                    format: Some(DataFormat::Turtle),
                 },
-                format: Some(DataFormat::Turtle),
-            },
-            DescribeResponse {
-                format: DataFormat::Turtle,
-                data: Binary::from(
-                   "<https://ontology.okp4.space/dataverse/dataspace/metadata/dcf48417-01c5-4b43-9bc7-49e54c028473> <http://www.w3.org/1999/02/22-rdf-syntax-ns#type> <https://ontology.okp4.space/metadata/dataspace/GeneralMetadata> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;\n\t<https://ontology.okp4.space/core/hasTag> \"Test\" , \"OKP4\" ;\n\t<https://ontology.okp4.space/core/hasTitle> \"Data Space de test\"@fr , \"Test Data Space\"@en ;\n\t<https://ontology.okp4.space/core/hasTopic> <https://ontology.okp4.space/thesaurus/topic/Test> ;\n\t<https://ontology.okp4.space/core/describes> <https://ontology.okp4.space/dataverse/dataspace/97ff7e16-c08d-47be-8475-211016c82e33> ;\n\t<https://ontology.okp4.space/core/hasPublisher> \"OKP4\" ;\n\t<https://ontology.okp4.space/core/hasDescription> \"A test Data Space.\"@en , \"Un Data Space de test.\"@fr .\n<https://ontology.okp4.space/dataverse/dataset/metadata/d1615703-4ee1-4e2f-997e-15aecf1eea4e> <http://www.w3.org/1999/02/22-rdf-syntax-ns#type> <https://ontology.okp4.space/metadata/dataset/GeneralMetadata> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;\n\t<https://ontology.okp4.space/core/hasTag> \"test\" ;\n\t<https://ontology.okp4.space/core/hasTitle> \"test Dataset\"@en , \"Dataset de test\"@fr ;\n\t<https://ontology.okp4.space/core/hasTopic> <https://ontology.okp4.space/thesaurus/topic/Test> ;\n\t<https://ontology.okp4.space/core/describes> <https://ontology.okp4.space/dataverse/dataset/0ea1fc7a-dd97-4adc-a10e-169c6597bcde> ;\n\t<https://ontology.okp4.space/core/hasFormat> <https://ontology.okp4.space/thesaurus/media-type/application_vndms-excel> ;\n\t<https://ontology.okp4.space/core/hasCreator> \"Me\" ;\n\t<https://ontology.okp4.space/core/hasLicense> <https://ontology.okp4.space/thesaurus/license/LO-FR-1_0> ;\n\t<https://ontology.okp4.space/core/hasPublisher> \"OKP4\" ;\n\t<https://ontology.okp4.space/core/hasDescription> \"Un Dataset de test.\"@fr , \"A test Dataset.\"@en .\n".to_string().as_bytes().to_vec()),
-            }
-        ),
+                DescribeResponse {
+                    format: DataFormat::Turtle,
+                    data: Binary::from(
+                        "<https://ontology.okp4.space/dataverse/dataspace/metadata/dcf48417-01c5-4b43-9bc7-49e54c028473> <http://www.w3.org/1999/02/22-rdf-syntax-ns#type> <https://ontology.okp4.space/metadata/dataspace/GeneralMetadata> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;\n\t<https://ontology.okp4.space/core/hasTag> \"Test\" , \"OKP4\" ;\n\t<https://ontology.okp4.space/core/hasTitle> \"Data Space de test\"@fr , \"Test Data Space\"@en ;\n\t<https://ontology.okp4.space/core/hasTopic> <https://ontology.okp4.space/thesaurus/topic/Test> ;\n\t<https://ontology.okp4.space/core/describes> <https://ontology.okp4.space/dataverse/dataspace/97ff7e16-c08d-47be-8475-211016c82e33> ;\n\t<https://ontology.okp4.space/core/hasPublisher> \"OKP4\" ;\n\t<https://ontology.okp4.space/core/hasDescription> \"A test Data Space.\"@en , \"Un Data Space de test.\"@fr .\n<https://ontology.okp4.space/dataverse/dataset/metadata/d1615703-4ee1-4e2f-997e-15aecf1eea4e> <http://www.w3.org/1999/02/22-rdf-syntax-ns#type> <https://ontology.okp4.space/metadata/dataset/GeneralMetadata> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;\n\t<https://ontology.okp4.space/core/hasTag> \"test\" ;\n\t<https://ontology.okp4.space/core/hasTitle> \"test Dataset\"@en , \"Dataset de test\"@fr ;\n\t<https://ontology.okp4.space/core/hasTopic> <https://ontology.okp4.space/thesaurus/topic/Test> ;\n\t<https://ontology.okp4.space/core/describes> <https://ontology.okp4.space/dataverse/dataset/0ea1fc7a-dd97-4adc-a10e-169c6597bcde> ;\n\t<https://ontology.okp4.space/core/hasFormat> <https://ontology.okp4.space/thesaurus/media-type/application_vndms-excel> ;\n\t<https://ontology.okp4.space/core/hasCreator> \"Me\" ;\n\t<https://ontology.okp4.space/core/hasLicense> <https://ontology.okp4.space/thesaurus/license/LO-FR-1_0> ;\n\t<https://ontology.okp4.space/core/hasPublisher> \"OKP4\" ;\n\t<https://ontology.okp4.space/core/hasDescription> \"Un Dataset de test.\"@fr , \"A test Dataset.\"@en .\n".to_string().as_bytes().to_vec()),
+                }
+            ),
         ];
 
         let mut deps = mock_dependencies();
@@ -1813,33 +2034,33 @@ mod tests {
     #[test]
     fn blanknode_describe() {
         let cases = vec![
-        (
-            QueryMsg::Describe {
-                query: DescribeQuery {
-                    prefixes: vec![
-                        Prefix { prefix: "core".to_string(), namespace: "https://ontology.okp4.space/core/".to_string() },
-                        Prefix { prefix: "metadata-dataset".to_string(), namespace: "https://ontology.okp4.space/dataverse/dataset/metadata/".to_string()}
-                    ],
-                    resource: VarOrNamedNode::Variable("x".to_string()),
-                    r#where: vec![WhereCondition::Simple(TriplePattern(
-                        msg::TriplePattern {
-                            subject: VarOrNode::Node(NamedNode(Prefixed("metadata-dataset:80b1f84e-86dc-4730-b54f-701ad9b1888a".to_string()))),
-                            predicate: VarOrNode::Node(NamedNode(Prefixed(
-                                "core:hasTemporalCoverage".to_string(),
-                            ))),
-                            object: VarOrNodeOrLiteral::Variable("x".to_string()),
-                        },
-                       )),
-                       ],
+            (
+                QueryMsg::Describe {
+                    query: DescribeQuery {
+                        prefixes: vec![
+                            Prefix { prefix: "core".to_string(), namespace: "https://ontology.okp4.space/core/".to_string() },
+                            Prefix { prefix: "metadata-dataset".to_string(), namespace: "https://ontology.okp4.space/dataverse/dataset/metadata/".to_string() },
+                        ],
+                        resource: VarOrNamedNode::Variable("x".to_string()),
+                        r#where: vec![WhereCondition::Simple(TriplePattern(
+                            msg::TriplePattern {
+                                subject: VarOrNode::Node(NamedNode(Prefixed("metadata-dataset:80b1f84e-86dc-4730-b54f-701ad9b1888a".to_string()))),
+                                predicate: VarOrNode::Node(NamedNode(Prefixed(
+                                    "core:hasTemporalCoverage".to_string(),
+                                ))),
+                                object: VarOrNodeOrLiteral::Variable("x".to_string()),
+                            },
+                        )),
+                        ],
+                    },
+                    format: Some(DataFormat::Turtle),
                 },
-                format: Some(DataFormat::Turtle),
-            },
-            DescribeResponse {
-                format: DataFormat::Turtle,
-                data: Binary::from(
-                    "<riog00000001> <http://www.w3.org/1999/02/22-rdf-syntax-ns#type> <http://www.w3.org/2002/07/owl#NamedIndividual> , <https://ontology.okp4.space/core/Period> ;\n\t<https://ontology.okp4.space/core/hasStartDate> \"2022-01-01T00:00:00+00:00\"^^<http://www.w3.org/2001/XMLSchema#dateTime> .\n".to_string().as_bytes().to_vec()),
-            }
-        ),
+                DescribeResponse {
+                    format: DataFormat::Turtle,
+                    data: Binary::from(
+                        "<riog00000001> <http://www.w3.org/1999/02/22-rdf-syntax-ns#type> <http://www.w3.org/2002/07/owl#NamedIndividual> , <https://ontology.okp4.space/core/Period> ;\n\t<https://ontology.okp4.space/core/hasStartDate> \"2022-01-01T00:00:00+00:00\"^^<http://www.w3.org/2001/XMLSchema#dateTime> .\n".to_string().as_bytes().to_vec()),
+                }
+            ),
         ];
 
         let mut deps = mock_dependencies();
@@ -1883,58 +2104,58 @@ mod tests {
     fn proper_construct() {
         let id = "https://ontology.okp4.space/dataverse/dataspace/metadata/dcf48417-01c5-4b43-9bc7-49e54c028473";
         let cases = vec![(
-            QueryMsg::Construct {
-                query: ConstructQuery {
-                    prefixes: vec![],
-                    construct: vec![],
-                    r#where: vec![WhereCondition::Simple(TriplePattern(msg::TriplePattern {
-                        subject: VarOrNode::Node(NamedNode(Full(id.to_string()))),
-                        predicate: VarOrNode::Node(NamedNode(Full(
-                            "https://ontology.okp4.space/core/hasTag".to_string(),
-                        ))),
-                        object: VarOrNodeOrLiteral::Variable("o".to_string()),
-                    }))],
-                },
-                format: None,
-            },
-            ConstructResponse {
-                format: DataFormat::Turtle,
-                data: Binary::from(
-                    "<https://ontology.okp4.space/dataverse/dataspace/metadata/dcf48417-01c5-4b43-9bc7-49e54c028473> <https://ontology.okp4.space/core/hasTag> \"Test\" , \"OKP4\" .\n".to_string().as_bytes().to_vec()),
-            },
-        ),
-        (
-            QueryMsg::Construct {
-                query: ConstructQuery {
-                    prefixes: vec![
-                        Prefix { prefix: "my-ns".to_string(), namespace: "https://my-ns.org/".to_string() },
-                        Prefix { prefix: "metadata-dataset".to_string(), namespace: "https://ontology.okp4.space/dataverse/dataset/metadata/".to_string()}
-                    ],
-                    construct: vec![
-                        msg::TriplePattern {
-                            subject: VarOrNode::Node(NamedNode(Prefixed("my-ns:instance-1".to_string()))),
-                            predicate: VarOrNode::Node(NamedNode(Full(
-                                "https://my-ns/predicate/tag".to_string(),
-                            ))),
-                            object: VarOrNodeOrLiteral::Variable("o".to_string()),
-                        }
-                    ],
-                    r#where: vec![WhereCondition::Simple(TriplePattern(msg::TriplePattern {
-                        subject: VarOrNode::Node(NamedNode(Full(id.to_string()))),
-                        predicate: VarOrNode::Node(NamedNode(Full(
-                            "https://ontology.okp4.space/core/hasTag".to_string(),
-                        ))),
-                        object: VarOrNodeOrLiteral::Variable("o".to_string()),
-                    }))],
-                },
-                format: Some(DataFormat::NTriples),
-            },
-            ConstructResponse {
-                format: DataFormat::NTriples,
-                data: Binary::from(
-                    "<https://my-ns.org/instance-1> <https://my-ns/predicate/tag> \"Test\" .\n<https://my-ns.org/instance-1> <https://my-ns/predicate/tag> \"OKP4\" .\n".to_string().as_bytes().to_vec()),
-            },
-        )];
+                             QueryMsg::Construct {
+                                 query: ConstructQuery {
+                                     prefixes: vec![],
+                                     construct: vec![],
+                                     r#where: vec![WhereCondition::Simple(TriplePattern(msg::TriplePattern {
+                                         subject: VarOrNode::Node(NamedNode(Full(id.to_string()))),
+                                         predicate: VarOrNode::Node(NamedNode(Full(
+                                             "https://ontology.okp4.space/core/hasTag".to_string(),
+                                         ))),
+                                         object: VarOrNodeOrLiteral::Variable("o".to_string()),
+                                     }))],
+                                 },
+                                 format: None,
+                             },
+                             ConstructResponse {
+                                 format: DataFormat::Turtle,
+                                 data: Binary::from(
+                                     "<https://ontology.okp4.space/dataverse/dataspace/metadata/dcf48417-01c5-4b43-9bc7-49e54c028473> <https://ontology.okp4.space/core/hasTag> \"Test\" , \"OKP4\" .\n".to_string().as_bytes().to_vec()),
+                             },
+                         ),
+                         (
+                             QueryMsg::Construct {
+                                 query: ConstructQuery {
+                                     prefixes: vec![
+                                         Prefix { prefix: "my-ns".to_string(), namespace: "https://my-ns.org/".to_string() },
+                                         Prefix { prefix: "metadata-dataset".to_string(), namespace: "https://ontology.okp4.space/dataverse/dataset/metadata/".to_string() },
+                                     ],
+                                     construct: vec![
+                                         msg::TriplePattern {
+                                             subject: VarOrNode::Node(NamedNode(Prefixed("my-ns:instance-1".to_string()))),
+                                             predicate: VarOrNode::Node(NamedNode(Full(
+                                                 "https://my-ns/predicate/tag".to_string(),
+                                             ))),
+                                             object: VarOrNodeOrLiteral::Variable("o".to_string()),
+                                         }
+                                     ],
+                                     r#where: vec![WhereCondition::Simple(TriplePattern(msg::TriplePattern {
+                                         subject: VarOrNode::Node(NamedNode(Full(id.to_string()))),
+                                         predicate: VarOrNode::Node(NamedNode(Full(
+                                             "https://ontology.okp4.space/core/hasTag".to_string(),
+                                         ))),
+                                         object: VarOrNodeOrLiteral::Variable("o".to_string()),
+                                     }))],
+                                 },
+                                 format: Some(DataFormat::NTriples),
+                             },
+                             ConstructResponse {
+                                 format: DataFormat::NTriples,
+                                 data: Binary::from(
+                                     "<https://my-ns.org/instance-1> <https://my-ns/predicate/tag> \"Test\" .\n<https://my-ns.org/instance-1> <https://my-ns/predicate/tag> \"OKP4\" .\n".to_string().as_bytes().to_vec()),
+                             },
+                         )];
 
         for (q, expected) in cases {
             let mut deps = mock_dependencies();

--- a/contracts/okp4-cognitarium/src/querier/engine.rs
+++ b/contracts/okp4-cognitarium/src/querier/engine.rs
@@ -253,16 +253,8 @@ impl<'a> TriplePatternIterator<'a> {
         blank_filters: (bool, bool),
     ) -> Box<dyn Iterator<Item = StdResult<Triple>> + 'a> {
         let post_filter = move |t: &Triple| {
-            let s = !blank_filters.0
-                || match t.subject {
-                    Subject::Blank(_) => true,
-                    _ => false,
-                };
-            let o = !blank_filters.1
-                || match t.object {
-                    Object::Blank(_) => true,
-                    _ => false,
-                };
+            let s = !blank_filters.0 || matches!(t.subject, Subject::Blank(_));
+            let o = !blank_filters.1 || matches!(t.object, Object::Blank(_));
             o && s
         };
 
@@ -420,11 +412,11 @@ impl<'a> Iterator for TriplePatternIterator<'a> {
         let next = self.triple_iter.next()?;
 
         let maybe_next = match next {
-            Ok(triple) => self.map_triple(triple).map(|r| Ok(r)),
+            Ok(triple) => self.map_triple(triple).map(Ok),
             Err(e) => Some(Err(e)),
         };
 
-        if maybe_next == None {
+        if maybe_next.is_none() {
             return self.next();
         }
         maybe_next

--- a/contracts/okp4-cognitarium/src/querier/engine.rs
+++ b/contracts/okp4-cognitarium/src/querier/engine.rs
@@ -1473,6 +1473,22 @@ mod test {
                 )),
             },
             TestCase {
+                subject: PatternValue::BlankVariable(0),
+                predicate: PatternValue::Variable(4),
+                object: PatternValue::BlankVariable(5),
+                expects: Some((
+                    (None, None, None),
+                    (true, true),
+                    (Some(0), Some(4), Some(5)),
+                )),
+            },
+            TestCase {
+                subject: PatternValue::BlankVariable(0),
+                predicate: PatternValue::BlankVariable(4),
+                object: PatternValue::BlankVariable(5),
+                expects: None,
+            },
+            TestCase {
                 subject: PatternValue::Variable(1),
                 predicate: PatternValue::Variable(4),
                 object: PatternValue::Variable(5),

--- a/contracts/okp4-cognitarium/src/querier/engine.rs
+++ b/contracts/okp4-cognitarium/src/querier/engine.rs
@@ -355,10 +355,14 @@ impl<'a> TriplePatternIterator<'a> {
     )> {
         let (s_filter, sb_filter, s_bind) =
             Self::resolve_pattern_part(subject, ResolvedVariable::as_subject, input)?;
-        let (p_filter, _, p_bind) =
+        let (p_filter, pb_filter, p_bind) =
             Self::resolve_pattern_part(predicate, ResolvedVariable::as_predicate, input)?;
         let (o_filter, ob_filter, o_bind) =
             Self::resolve_pattern_part(object, ResolvedVariable::as_object, input)?;
+
+        if pb_filter {
+            None?;
+        }
 
         Some((
             (s_filter, p_filter, o_filter),

--- a/contracts/okp4-cognitarium/src/querier/plan_builder.rs
+++ b/contracts/okp4-cognitarium/src/querier/plan_builder.rs
@@ -1,10 +1,9 @@
 use crate::msg::{
-    SimpleWhereCondition, TriplePattern, VarOrNode, VarOrNodeOrLiteral, WhereClause, WhereCondition,
+    Node, SimpleWhereCondition, TriplePattern, VarOrNode, VarOrNodeOrLiteral, WhereClause,
+    WhereCondition,
 };
-use crate::querier::mapper::{
-    literal_as_object, node_as_object, node_as_predicate, node_as_subject,
-};
-use crate::querier::plan::{PatternValue, QueryNode, QueryPlan};
+use crate::querier::mapper::{iri_as_node, literal_as_object, node_as_predicate};
+use crate::querier::plan::{PatternValue, PlanVariable, QueryNode, QueryPlan};
 use crate::state::{HasCachedNamespaces, Namespace, NamespaceResolver, Object, Predicate, Subject};
 use cosmwasm_std::{StdError, StdResult, Storage};
 use std::collections::HashMap;
@@ -13,7 +12,7 @@ pub struct PlanBuilder<'a> {
     storage: &'a dyn Storage,
     ns_resolver: NamespaceResolver,
     prefixes: &'a HashMap<String, String>,
-    variables: Vec<String>,
+    variables: Vec<PlanVariable>,
     limit: Option<usize>,
     skip: Option<usize>,
 }
@@ -143,19 +142,19 @@ impl<'a> PlanBuilder<'a> {
 
     fn build_subject_pattern(&mut self, value: VarOrNode) -> StdResult<PatternValue<Subject>> {
         Ok(match value {
-            VarOrNode::Variable(v) => PatternValue::Variable(self.resolve_variable(v)),
-            VarOrNode::Node(n) => PatternValue::Constant(node_as_subject(
-                &mut self.ns_resolver,
-                self.storage,
-                self.prefixes,
-                n,
-            )?),
+            VarOrNode::Variable(v) => PatternValue::Variable(self.resolve_basic_variable(v)),
+            VarOrNode::Node(Node::BlankNode(b)) => {
+                PatternValue::BlankVariable(self.resolve_blank_variable(b))
+            }
+            VarOrNode::Node(Node::NamedNode(iri)) => PatternValue::Constant(Subject::Named(
+                iri_as_node(&mut self.ns_resolver, self.storage, self.prefixes, iri)?,
+            )),
         })
     }
 
     fn build_predicate_pattern(&mut self, value: VarOrNode) -> StdResult<PatternValue<Predicate>> {
         Ok(match value {
-            VarOrNode::Variable(v) => PatternValue::Variable(self.resolve_variable(v)),
+            VarOrNode::Variable(v) => PatternValue::Variable(self.resolve_basic_variable(v)),
             VarOrNode::Node(n) => PatternValue::Constant(node_as_predicate(
                 &mut self.ns_resolver,
                 self.storage,
@@ -170,13 +169,20 @@ impl<'a> PlanBuilder<'a> {
         value: VarOrNodeOrLiteral,
     ) -> StdResult<PatternValue<Object>> {
         Ok(match value {
-            VarOrNodeOrLiteral::Variable(v) => PatternValue::Variable(self.resolve_variable(v)),
-            VarOrNodeOrLiteral::Node(n) => PatternValue::Constant(node_as_object(
-                &mut self.ns_resolver,
-                self.storage,
-                self.prefixes,
-                n,
-            )?),
+            VarOrNodeOrLiteral::Variable(v) => {
+                PatternValue::Variable(self.resolve_basic_variable(v))
+            }
+            VarOrNodeOrLiteral::Node(Node::BlankNode(b)) => {
+                PatternValue::BlankVariable(self.resolve_blank_variable(b))
+            }
+            VarOrNodeOrLiteral::Node(Node::NamedNode(iri)) => {
+                PatternValue::Constant(Object::Named(iri_as_node(
+                    &mut self.ns_resolver,
+                    self.storage,
+                    self.prefixes,
+                    iri,
+                )?))
+            }
             VarOrNodeOrLiteral::Literal(l) => PatternValue::Constant(literal_as_object(
                 &mut self.ns_resolver,
                 self.storage,
@@ -186,12 +192,27 @@ impl<'a> PlanBuilder<'a> {
         })
     }
 
-    fn resolve_variable(&mut self, v: String) -> usize {
-        if let Some(index) = self.variables.iter().position(|name| name == &v) {
+    fn resolve_basic_variable(&mut self, v: String) -> usize {
+        if let Some(index) = self.variables.iter().position(|var| match var {
+            PlanVariable::Basic(name) => name == &v,
+            PlanVariable::BlankNode(_) => false,
+        }) {
             return index;
         }
 
-        self.variables.push(v);
+        self.variables.push(PlanVariable::Basic(v));
+        self.variables.len() - 1
+    }
+
+    fn resolve_blank_variable(&mut self, v: String) -> usize {
+        if let Some(index) = self.variables.iter().position(|var| match var {
+            PlanVariable::BlankNode(name) => name == &v,
+            PlanVariable::Basic(_) => false,
+        }) {
+            return index;
+        }
+
+        self.variables.push(PlanVariable::BlankNode(v));
         self.variables.len() - 1
     }
 }
@@ -275,7 +296,7 @@ mod test {
             let builder = PlanBuilder::new(&deps.storage, prefixes, None);
             assert_eq!(builder.skip, None);
             assert_eq!(builder.limit, None);
-            assert_eq!(builder.variables, Vec::<String>::new());
+            assert_eq!(builder.variables, Vec::<PlanVariable>::new());
             assert_eq!(builder.prefixes, &case.1);
         }
 
@@ -307,19 +328,19 @@ mod test {
             ),
             (
                 TriplePattern {
-                    subject: VarOrNode::Node(Node::BlankNode("_".to_string())),
+                    subject: VarOrNode::Node(Node::BlankNode("1".to_string())),
                     predicate: VarOrNode::Node(Node::NamedNode(IRI::Full(
                         "http://okp4.space/hasTitle".to_string(),
                     ))),
-                    object: VarOrNodeOrLiteral::Node(Node::BlankNode("_".to_string())),
+                    object: VarOrNodeOrLiteral::Node(Node::BlankNode("2".to_string())),
                 },
                 Ok(QueryNode::TriplePattern {
-                    subject: PatternValue::Constant(Subject::Blank("_".to_string())),
+                    subject: PatternValue::BlankVariable(0usize),
                     predicate: PatternValue::Constant(state::Node {
                         namespace: 0u128,
                         value: "hasTitle".to_string(),
                     }),
-                    object: PatternValue::Constant(Object::Blank("_".to_string())),
+                    object: PatternValue::BlankVariable(1usize),
                 }),
             ),
             (
@@ -337,7 +358,7 @@ mod test {
                         namespace: 0u128,
                         value: "123456789".to_string(),
                     })),
-                    predicate: PatternValue::Variable(1usize),
+                    predicate: PatternValue::Variable(0usize),
                     object: PatternValue::Constant(Object::Named(state::Node {
                         namespace: 0u128,
                         value: "1234567892".to_string(),
@@ -351,8 +372,8 @@ mod test {
                     object: VarOrNodeOrLiteral::Literal(Literal::Simple("simple".to_string())),
                 },
                 Ok(QueryNode::TriplePattern {
-                    subject: PatternValue::Variable(1usize),
-                    predicate: PatternValue::Variable(0usize),
+                    subject: PatternValue::Variable(0usize),
+                    predicate: PatternValue::Variable(1usize),
                     object: PatternValue::Constant(Object::Literal(state::Literal::Simple {
                         value: "simple".to_string(),
                     })),
@@ -406,7 +427,7 @@ mod test {
                     object: VarOrNodeOrLiteral::Variable("o".to_string()),
                 },
                 Ok(QueryNode::Noop {
-                    bound_variables: vec![1usize, 2usize],
+                    bound_variables: vec![0usize, 1usize],
                 }),
             ),
             (
@@ -418,7 +439,7 @@ mod test {
                     object: VarOrNodeOrLiteral::Variable("o".to_string()),
                 },
                 Ok(QueryNode::Noop {
-                    bound_variables: vec![0usize, 2usize],
+                    bound_variables: vec![0usize, 1usize],
                 }),
             ),
             (
@@ -447,10 +468,10 @@ mod test {
                 },
             )
             .unwrap();
-        let prefixes = &PrefixMap::default().into_inner();
-        let mut builder = PlanBuilder::new(&deps.storage, prefixes, None);
-
         for case in cases {
+            let prefixes = &PrefixMap::default().into_inner();
+            let mut builder = PlanBuilder::new(&deps.storage, prefixes, None);
+
             assert_eq!(builder.build_triple_pattern(&case.0), case.1);
         }
     }
@@ -490,7 +511,10 @@ mod test {
                     entrypoint: QueryNode::Noop {
                         bound_variables: vec![0usize, 1usize],
                     },
-                    variables: vec!["predicate".to_string(), "object".to_string()],
+                    variables: vec![
+                        PlanVariable::Basic("predicate".to_string()),
+                        PlanVariable::Basic("object".to_string()),
+                    ],
                 }),
             ),
             (
@@ -508,9 +532,9 @@ mod test {
                         object: PatternValue::Variable(2usize),
                     },
                     variables: vec![
-                        "subject".to_string(),
-                        "predicate".to_string(),
-                        "object".to_string(),
+                        PlanVariable::Basic("subject".to_string()),
+                        PlanVariable::Basic("predicate".to_string()),
+                        PlanVariable::Basic("object".to_string()),
                     ],
                 }),
             ),
@@ -532,9 +556,9 @@ mod test {
                         }),
                     },
                     variables: vec![
-                        "subject".to_string(),
-                        "predicate".to_string(),
-                        "object".to_string(),
+                        PlanVariable::Basic("subject".to_string()),
+                        PlanVariable::Basic("predicate".to_string()),
+                        PlanVariable::Basic("object".to_string()),
                     ],
                 }),
             ),
@@ -556,9 +580,9 @@ mod test {
                         }),
                     },
                     variables: vec![
-                        "subject".to_string(),
-                        "predicate".to_string(),
-                        "object".to_string(),
+                        PlanVariable::Basic("subject".to_string()),
+                        PlanVariable::Basic("predicate".to_string()),
+                        PlanVariable::Basic("object".to_string()),
                     ],
                 }),
             ),
@@ -583,9 +607,9 @@ mod test {
                         }),
                     },
                     variables: vec![
-                        "subject".to_string(),
-                        "predicate".to_string(),
-                        "object".to_string(),
+                        PlanVariable::Basic("subject".to_string()),
+                        PlanVariable::Basic("predicate".to_string()),
+                        PlanVariable::Basic("object".to_string()),
                     ],
                 }),
             ),
@@ -626,16 +650,17 @@ mod test {
                         right: Box::new(QueryNode::TriplePattern {
                             subject: PatternValue::Variable(0usize),
                             predicate: PatternValue::Variable(4usize),
-                            object: PatternValue::Constant(Object::Blank("blank".to_string())),
+                            object: PatternValue::BlankVariable(6usize),
                         }),
                     },
                     variables: vec![
-                        "var1".to_string(),
-                        "var2".to_string(),
-                        "var3".to_string(),
-                        "var4".to_string(),
-                        "var5".to_string(),
-                        "var6".to_string(),
+                        PlanVariable::Basic("var1".to_string()),
+                        PlanVariable::Basic("var2".to_string()),
+                        PlanVariable::Basic("var3".to_string()),
+                        PlanVariable::Basic("var4".to_string()),
+                        PlanVariable::Basic("var5".to_string()),
+                        PlanVariable::Basic("var6".to_string()),
+                        PlanVariable::BlankNode("blank".to_string()),
                     ],
                 }),
             ),

--- a/contracts/okp4-cognitarium/src/querier/plan_builder.rs
+++ b/contracts/okp4-cognitarium/src/querier/plan_builder.rs
@@ -664,6 +664,42 @@ mod test {
                     ],
                 }),
             ),
+            (
+                None,
+                None,
+                vec![
+                    TriplePattern {
+                        subject: VarOrNode::Node(Node::BlankNode("1".to_string())),
+                        predicate: VarOrNode::Variable("1".to_string()),
+                        object: VarOrNodeOrLiteral::Node(Node::BlankNode("2".to_string())),
+                    },
+                    TriplePattern {
+                        subject: VarOrNode::Node(Node::BlankNode("1".to_string())),
+                        predicate: VarOrNode::Variable("1".to_string()),
+                        object: VarOrNodeOrLiteral::Variable("2".to_string()),
+                    },
+                ],
+                Ok(QueryPlan {
+                    entrypoint: QueryNode::ForLoopJoin {
+                        left: Box::new(QueryNode::TriplePattern {
+                            subject: PatternValue::BlankVariable(0usize),
+                            predicate: PatternValue::Variable(1usize),
+                            object: PatternValue::BlankVariable(2usize),
+                        }),
+                        right: Box::new(QueryNode::TriplePattern {
+                            subject: PatternValue::BlankVariable(0usize),
+                            predicate: PatternValue::Variable(1usize),
+                            object: PatternValue::Variable(3usize),
+                        }),
+                    },
+                    variables: vec![
+                        PlanVariable::BlankNode("1".to_string()),
+                        PlanVariable::Basic("1".to_string()),
+                        PlanVariable::BlankNode("2".to_string()),
+                        PlanVariable::Basic("2".to_string()),
+                    ],
+                }),
+            ),
         ];
 
         let mut deps = mock_dependencies();

--- a/contracts/okp4-cognitarium/src/querier/variable.rs
+++ b/contracts/okp4-cognitarium/src/querier/variable.rs
@@ -131,8 +131,13 @@ impl ResolvedVariables {
         Some(Self { variables: merged })
     }
 
-    pub fn set(&mut self, index: usize, var: ResolvedVariable) {
-        self.variables[index] = Some(var);
+    pub fn merge_index(&mut self, index: usize, var: ResolvedVariable) -> Option<()> {
+        if let Some(old) = self.get(index) {
+            (*old == var).then(|| ())
+        } else {
+            self.variables[index] = Some(var);
+            Some(())
+        }
     }
 
     pub fn get(&self, index: usize) -> &Option<ResolvedVariable> {
@@ -295,21 +300,21 @@ mod tests {
     #[test]
     fn merged_variables() {
         let mut vars1 = ResolvedVariables::with_capacity(3);
-        vars1.set(
+        vars1.merge_index(
             0,
             ResolvedVariable::Object(Object::Blank("foo".to_string())),
         );
-        vars1.set(
+        vars1.merge_index(
             2,
             ResolvedVariable::Object(Object::Blank("bar".to_string())),
         );
 
         let mut vars2 = ResolvedVariables::with_capacity(3);
-        vars2.set(
+        vars2.merge_index(
             1,
             ResolvedVariable::Object(Object::Blank("pop".to_string())),
         );
-        vars2.set(
+        vars2.merge_index(
             2,
             ResolvedVariable::Object(Object::Blank("bar".to_string())),
         );
@@ -321,15 +326,15 @@ mod tests {
         assert_eq!(vars1.get(1), &None);
 
         let mut expected_result = ResolvedVariables::with_capacity(3);
-        expected_result.set(
+        expected_result.merge_index(
             0,
             ResolvedVariable::Object(Object::Blank("foo".to_string())),
         );
-        expected_result.set(
+        expected_result.merge_index(
             1,
             ResolvedVariable::Object(Object::Blank("pop".to_string())),
         );
-        expected_result.set(
+        expected_result.merge_index(
             2,
             ResolvedVariable::Object(Object::Blank("bar".to_string())),
         );
@@ -338,11 +343,11 @@ mod tests {
         assert_eq!(result, Some(expected_result));
 
         let mut vars3 = ResolvedVariables::with_capacity(3);
-        vars3.set(
+        vars3.merge_index(
             1,
             ResolvedVariable::Object(Object::Blank("pop".to_string())),
         );
-        vars3.set(
+        vars3.merge_index(
             2,
             ResolvedVariable::Predicate(Node {
                 namespace: 0,

--- a/contracts/okp4-cognitarium/src/querier/variable.rs
+++ b/contracts/okp4-cognitarium/src/querier/variable.rs
@@ -133,7 +133,7 @@ impl ResolvedVariables {
 
     pub fn merge_index(&mut self, index: usize, var: ResolvedVariable) -> Option<()> {
         if let Some(old) = self.get(index) {
-            (*old == var).then(|| ())
+            (*old == var).then_some(())
         } else {
             self.variables[index] = Some(var);
             Some(())

--- a/contracts/okp4-cognitarium/testdata/blank-nodes.ttl
+++ b/contracts/okp4-cognitarium/testdata/blank-nodes.ttl
@@ -28,6 +28,9 @@
       a owl:NamedIndividual, core:Period ; 
       core:hasStartDate "2022-01-01T00:00:00+00:00"^^xsd:dateTime 
   ] ;
+  core:hasInformations [
+      core:hasInformation "this is a dataset"
+  ] ;
   core:hasTitle "ADMIN EXPRESS COG 2022 COMMUNE"@fr ;
   core:hasTitle "ADMIN EXPRESS COG 2022 CITY"@en ;
   core:hasTitle "ADMIN EXPRESS COG 2022 GEMEINDE"@de ;

--- a/contracts/okp4-dataverse/src/registrar/credential.rs
+++ b/contracts/okp4-dataverse/src/registrar/credential.rs
@@ -29,7 +29,7 @@ impl<'a> DataverseCredential<'a> {
                     "credential is expected to have exactly one type".to_string(),
                 )
             })
-            .map(|t| *t)
+            .copied()
     }
 
     fn extract_vc_claim(


### PR DESCRIPTION
Following the conversation on https://github.com/okp4/contracts/issues/494, blank nodes will be kept as part of the querying interface, this PR addresses an issue pointed out in a [comment](https://github.com/okp4/contracts/issues/494#issuecomment-1964941769) regarding the management of those blank nodes.

## Details

When providing a blank node in a triple pattern, its value (i.e. the provided id for the blank node) was checked against the triples in the state, which is a non-sense as blank nodes identifiers are ephemeral.

In such case the query engine shall only ensure the relations expressed through blank nodes in triple patterns.

## Proposed solution

The proposed solution consider a blank nodes triple patterns inputs as variables, a special type of variables linked to a blank node so that the querying engine can enforce values to be effectively blank nodes. Those variables are treated specially to prevent them from being used as `SelectItem`.

## Misc

Another fix as been done here, when using the same variable multiple times in a single triple pattern, it could have the same value..

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
  - Added a new property `core:hasInformations` to entities in multiple languages for enhanced dataset information.
  - Replaced the `map` function with `copied` in `DataverseCredential` implementation for improved data processing.

- **Refactor**
  - Modified the `TriplePatternIterator` struct to include `blank_filters` for advanced filtering in queries.
  - Updated `QueryPlan` to use `PlanVariable` enums for better variable handling and resolution.
  - Adjusted `PlanBuilder` methods for improved variable management and pattern construction in query planning.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->