### PR TITLE
Fix/blank node identifier

### DIFF
--- a/contracts/okp4-cognitarium/src/contract.rs
+++ b/contracts/okp4-cognitarium/src/contract.rs
@@ -196,7 +196,7 @@ pub mod query {
             VarOrNamedNode::Variable(var) => {
                 let select = TriplePattern {
                     subject: VarOrNode::Variable(var.clone()),
-                    predicate: VarOrNode::Variable(format!("{var}{p}")),
+                    predicate: VarOrNamedNode::Variable(format!("{var}{p}")),
                     object: VarOrNodeOrLiteral::Variable(format!("{var}{o}")),
                 };
 
@@ -210,7 +210,7 @@ pub mod query {
             VarOrNamedNode::NamedNode(iri) => {
                 let select = TriplePattern {
                     subject: VarOrNode::Node(Node::NamedNode(iri.clone())),
-                    predicate: VarOrNode::Variable(p),
+                    predicate: VarOrNamedNode::Variable(p),
                     object: VarOrNodeOrLiteral::Variable(o),
                 };
 

--- a/contracts/okp4-cognitarium/src/contract.rs
+++ b/contracts/okp4-cognitarium/src/contract.rs
@@ -287,15 +287,15 @@ pub mod query {
             .map(|t| TripleConstructTemplate {
                 subject: match t.subject {
                     VarOrNode::Node(Node::BlankNode(n)) => {
-                        VarOrNode::Node(Node::BlankNode(id_issuer.get_str_or_issue(n.clone())))
+                        VarOrNode::Node(Node::BlankNode(id_issuer.get_str_or_issue(n)))
                     }
                     _ => t.subject,
                 },
                 predicate: t.predicate,
                 object: match t.object {
-                    VarOrNodeOrLiteral::Node(Node::BlankNode(n)) => VarOrNodeOrLiteral::Node(
-                        Node::BlankNode(id_issuer.get_str_or_issue(n.clone())),
-                    ),
+                    VarOrNodeOrLiteral::Node(Node::BlankNode(n)) => {
+                        VarOrNodeOrLiteral::Node(Node::BlankNode(id_issuer.get_str_or_issue(n)))
+                    }
                     _ => t.object,
                 },
             })

--- a/contracts/okp4-cognitarium/src/contract.rs
+++ b/contracts/okp4-cognitarium/src/contract.rs
@@ -140,7 +140,7 @@ pub mod execute {
                 .collect::<StdResult<Vec<Triple>>>()?
         } else {
             query_engine
-                .construct_triples(plan, delete_templates)?
+                .construct_triples(plan, delete_templates)
                 .collect::<StdResult<Vec<Triple>>>()?
         };
 

--- a/contracts/okp4-cognitarium/src/contract.rs
+++ b/contracts/okp4-cognitarium/src/contract.rs
@@ -563,6 +563,39 @@ mod tests {
     }
 
     #[test]
+    fn proper_insert_blank_nodes() {
+        let mut deps = mock_dependencies();
+
+        let info = mock_info("owner", &[]);
+        instantiate(
+            deps.as_mut(),
+            mock_env(),
+            info.clone(),
+            InstantiateMsg::default(),
+        )
+        .unwrap();
+
+        let insert_msg = InsertData {
+            format: None,
+            data: read_test_data("blank-nodes.ttl"),
+        };
+
+        let res = execute(deps.as_mut(), mock_env(), info.clone(), insert_msg.clone());
+        assert!(res.is_ok());
+        assert_eq!(
+            BLANK_NODE_IDENTIFIER_COUNTER.load(&deps.storage).unwrap(),
+            2u128
+        );
+
+        let res = execute(deps.as_mut(), mock_env(), info.clone(), insert_msg);
+        assert!(res.is_ok());
+        assert_eq!(
+            BLANK_NODE_IDENTIFIER_COUNTER.load(&deps.storage).unwrap(),
+            4u128
+        );
+    }
+
+    #[test]
     fn insert_existing_triples() {
         let mut deps = mock_dependencies();
 

--- a/contracts/okp4-cognitarium/src/contract.rs
+++ b/contracts/okp4-cognitarium/src/contract.rs
@@ -7,7 +7,7 @@ use cw2::set_contract_version;
 
 use crate::error::ContractError;
 use crate::msg::{DataFormat, ExecuteMsg, InstantiateMsg, QueryMsg};
-use crate::state::{Store, NAMESPACE_KEY_INCREMENT, STORE};
+use crate::state::{Store, BLANK_NODE_IDENTIFIER_COUNTER, NAMESPACE_KEY_INCREMENT, STORE};
 
 // version info for migration info
 const CONTRACT_NAME: &str = concat!("crates.io:", env!("CARGO_PKG_NAME"));
@@ -24,6 +24,7 @@ pub fn instantiate(
 
     STORE.save(deps.storage, &Store::new(info.sender, msg.limits.into()))?;
     NAMESPACE_KEY_INCREMENT.save(deps.storage, &0u128)?;
+    BLANK_NODE_IDENTIFIER_COUNTER.save(deps.storage, &0u128)?;
 
     Ok(Response::default())
 }
@@ -443,6 +444,10 @@ mod tests {
         );
 
         assert_eq!(NAMESPACE_KEY_INCREMENT.load(&deps.storage).unwrap(), 0u128);
+        assert_eq!(
+            BLANK_NODE_IDENTIFIER_COUNTER.load(&deps.storage).unwrap(),
+            0u128
+        );
     }
 
     #[test]

--- a/contracts/okp4-cognitarium/src/contract.rs
+++ b/contracts/okp4-cognitarium/src/contract.rs
@@ -274,12 +274,23 @@ pub mod query {
             prefixes,
             r#where,
         } = query;
-        if construct.is_empty() {
-            return Ok(ConstructResponse {
-                format,
-                data: Binary::from(vec![]),
-            });
-        }
+
+        let construct = if construct.is_empty() {
+            r#where
+                .iter()
+                .map(|t| match t {
+                    WhereCondition::Simple(SimpleWhereCondition::TriplePattern(t)) => {
+                        TripleConstructTemplate {
+                            subject: t.subject.clone(),
+                            predicate: t.predicate.clone(),
+                            object: t.object.clone(),
+                        }
+                    }
+                })
+                .collect()
+        } else {
+            construct
+        };
 
         let mut id_issuer = IdentifierIssuer::new("a", 0u128);
         let construct: Vec<_> = construct
@@ -2149,139 +2160,139 @@ mod tests {
     fn proper_construct() {
         let id = "https://ontology.okp4.space/dataverse/dataspace/metadata/dcf48417-01c5-4b43-9bc7-49e54c028473";
         let cases = vec![
-                        // (
-                        // InsertData {
-                        //     format: Some(DataFormat::RDFXml),
-                        //     data: read_test_data("sample.rdf.xml"),
-                        // },
-                        //      QueryMsg::Construct {
-                        //          query: ConstructQuery {
-                        //              prefixes: vec![],
-                        //              construct: vec![],
-                        //              r#where: vec![WhereCondition::Simple(TriplePattern(msg::TriplePattern {
-                        //                  subject: VarOrNode::Node(NamedNode(Full(id.to_string()))),
-                        //                  predicate: VarOrNamedNode::NamedNode(Full(
-                        //                      "https://ontology.okp4.space/core/hasTag".to_string(),
-                        //                  )),
-                        //                  object: VarOrNodeOrLiteral::Variable("o".to_string()),
-                        //              }))],
-                        //          },
-                        //          format: None,
-                        //      },
-                        //      ConstructResponse {
-                        //          format: DataFormat::Turtle,
-                        //          data: Binary::from(
-                        //              "<https://ontology.okp4.space/dataverse/dataspace/metadata/dcf48417-01c5-4b43-9bc7-49e54c028473> <https://ontology.okp4.space/core/hasTag> \"Test\" , \"OKP4\" .\n".to_string().as_bytes().to_vec()),
-                        //      },
-                        //  ),
-                        (
-                            InsertData {
-                                format: Some(DataFormat::RDFXml),
-                                data: read_test_data("sample.rdf.xml"),
+            (
+                InsertData {
+                    format: Some(DataFormat::RDFXml),
+                    data: read_test_data("sample.rdf.xml"),
+                },
+                QueryMsg::Construct {
+                    query: ConstructQuery {
+                        prefixes: vec![],
+                        construct: vec![],
+                        r#where: vec![WhereCondition::Simple(TriplePattern(msg::TriplePattern {
+                            subject: VarOrNode::Node(NamedNode(Full(id.to_string()))),
+                            predicate: VarOrNamedNode::NamedNode(Full(
+                                "https://ontology.okp4.space/core/hasTag".to_string(),
+                            )),
+                            object: VarOrNodeOrLiteral::Variable("o".to_string()),
+                        }))],
+                    },
+                    format: None,
+                },
+                ConstructResponse {
+                    format: DataFormat::Turtle,
+                    data: Binary::from(
+                        "<https://ontology.okp4.space/dataverse/dataspace/metadata/dcf48417-01c5-4b43-9bc7-49e54c028473> <https://ontology.okp4.space/core/hasTag> \"Test\" , \"OKP4\" .\n".to_string().as_bytes().to_vec()),
+                },
+            ),
+            (
+                InsertData {
+                    format: Some(DataFormat::RDFXml),
+                    data: read_test_data("sample.rdf.xml"),
+                },
+                QueryMsg::Construct {
+                    query: ConstructQuery {
+                        prefixes: vec![
+                            Prefix { prefix: "my-ns".to_string(), namespace: "https://my-ns.org/".to_string() },
+                            Prefix { prefix: "metadata-dataset".to_string(), namespace: "https://ontology.okp4.space/dataverse/dataset/metadata/".to_string() },
+                        ],
+                        construct: vec![
+                            msg::TripleConstructTemplate {
+                                subject: VarOrNode::Node(NamedNode(Prefixed("my-ns:instance-1".to_string()))),
+                                predicate: VarOrNamedNode::NamedNode(Full(
+                                    "https://my-ns/predicate/tag".to_string(),
+                                )),
+                                object: VarOrNodeOrLiteral::Variable("o".to_string()),
+                            }
+                        ],
+                        r#where: vec![WhereCondition::Simple(TriplePattern(msg::TriplePattern {
+                            subject: VarOrNode::Node(NamedNode(Full(id.to_string()))),
+                            predicate: VarOrNamedNode::NamedNode(Full(
+                                "https://ontology.okp4.space/core/hasTag".to_string(),
+                            )),
+                            object: VarOrNodeOrLiteral::Variable("o".to_string()),
+                        }))],
+                    },
+                    format: Some(DataFormat::NTriples),
+                },
+                ConstructResponse {
+                    format: DataFormat::NTriples,
+                    data: Binary::from(
+                        "<https://my-ns.org/instance-1> <https://my-ns/predicate/tag> \"Test\" .\n<https://my-ns.org/instance-1> <https://my-ns/predicate/tag> \"OKP4\" .\n".to_string().as_bytes().to_vec()),
+                },
+            ),
+            (
+                InsertData {
+                    format: Some(DataFormat::Turtle),
+                    data: read_test_data("blank-nodes.ttl"),
+                },
+                QueryMsg::Construct {
+                    query: ConstructQuery {
+                        prefixes: vec![
+                            Prefix { prefix: "core".to_string(), namespace: "https://ontology.okp4.space/core/".to_string() },
+                            Prefix { prefix: "metadata-dataset".to_string(), namespace: "https://ontology.okp4.space/dataverse/dataset/metadata/".to_string() },
+                        ],
+                        construct: vec![
+                            msg::TripleConstructTemplate {
+                                subject: VarOrNode::Node(BlankNode("my-metadata".to_string())),
+                                predicate: VarOrNamedNode::NamedNode(Full(
+                                    "https://my-ns/predicate/tcov".to_string(),
+                                )),
+                                object: VarOrNodeOrLiteral::Variable("tcov".to_string()),
                             },
-                            QueryMsg::Construct {
-                                query: ConstructQuery {
-                                    prefixes: vec![
-                                        Prefix { prefix: "my-ns".to_string(), namespace: "https://my-ns.org/".to_string() },
-                                        Prefix { prefix: "metadata-dataset".to_string(), namespace: "https://ontology.okp4.space/dataverse/dataset/metadata/".to_string() },
-                                    ],
-                                    construct: vec![
-                                        msg::TripleConstructTemplate {
-                                            subject: VarOrNode::Node(NamedNode(Prefixed("my-ns:instance-1".to_string()))),
-                                            predicate: VarOrNamedNode::NamedNode(Full(
-                                                "https://my-ns/predicate/tag".to_string(),
-                                            )),
-                                            object: VarOrNodeOrLiteral::Variable("o".to_string()),
-                                        }
-                                    ],
-                                    r#where: vec![WhereCondition::Simple(TriplePattern(msg::TriplePattern {
-                                        subject: VarOrNode::Node(NamedNode(Full(id.to_string()))),
-                                        predicate: VarOrNamedNode::NamedNode(Full(
-                                            "https://ontology.okp4.space/core/hasTag".to_string(),
-                                        )),
-                                        object: VarOrNodeOrLiteral::Variable("o".to_string()),
-                                    }))],
-                                },
-                                format: Some(DataFormat::NTriples),
+                            msg::TripleConstructTemplate {
+                                subject: VarOrNode::Node(BlankNode("my-metadata".to_string())),
+                                predicate: VarOrNamedNode::NamedNode(Full(
+                                    "https://my-ns/predicate/info".to_string(),
+                                )),
+                                object: VarOrNodeOrLiteral::Variable("info".to_string()),
                             },
-                            ConstructResponse {
-                                format: DataFormat::NTriples,
-                                data: Binary::from(
-                                    "<https://my-ns.org/instance-1> <https://my-ns/predicate/tag> \"Test\" .\n<https://my-ns.org/instance-1> <https://my-ns/predicate/tag> \"OKP4\" .\n".to_string().as_bytes().to_vec()),
+                            msg::TripleConstructTemplate {
+                                subject: VarOrNode::Variable("tcov".to_string()),
+                                predicate: VarOrNamedNode::Variable("tcov_p".to_string()),
+                                object: VarOrNodeOrLiteral::Variable("tcov_o".to_string()),
                             },
-                        ),
-                         (
-                             InsertData {
-                                format: Some(DataFormat::Turtle),
-                                data: read_test_data("blank-nodes.ttl"),
-                            },
-                             QueryMsg::Construct {
-                                 query: ConstructQuery {
-                                     prefixes: vec![
-                                         Prefix { prefix: "core".to_string(), namespace: "https://ontology.okp4.space/core/".to_string() },
-                                         Prefix { prefix: "metadata-dataset".to_string(), namespace: "https://ontology.okp4.space/dataverse/dataset/metadata/".to_string() },
-                                     ],
-                                     construct: vec![
-                                         msg::TripleConstructTemplate {
-                                             subject: VarOrNode::Node(BlankNode("my-metadata".to_string())),
-                                             predicate: VarOrNamedNode::NamedNode(Full(
-                                                 "https://my-ns/predicate/tcov".to_string(),
-                                             )),
-                                             object: VarOrNodeOrLiteral::Variable("tcov".to_string()),
-                                         },
-                                         msg::TripleConstructTemplate {
-                                             subject: VarOrNode::Node(BlankNode("my-metadata".to_string())),
-                                             predicate: VarOrNamedNode::NamedNode(Full(
-                                                 "https://my-ns/predicate/info".to_string(),
-                                             )),
-                                             object: VarOrNodeOrLiteral::Variable("info".to_string()),
-                                         },
-                                         msg::TripleConstructTemplate {
-                                             subject: VarOrNode::Variable("tcov".to_string()),
-                                             predicate: VarOrNamedNode::Variable("tcov_p".to_string()),
-                                             object: VarOrNodeOrLiteral::Variable("tcov_o".to_string()),
-                                         },
-                                         msg::TripleConstructTemplate {
-                                             subject: VarOrNode::Variable("info".to_string()),
-                                             predicate: VarOrNamedNode::Variable("info_p".to_string()),
-                                             object: VarOrNodeOrLiteral::Variable("info_o".to_string()),
-                                         }
-                                     ],
-                                     r#where: vec![
-                                         WhereCondition::Simple(TriplePattern(msg::TriplePattern {
-                                         subject: VarOrNode::Node(NamedNode(Prefixed("metadata-dataset:80b1f84e-86dc-4730-b54f-701ad9b1888a".to_string()))),
-                                         predicate: VarOrNamedNode::NamedNode(Prefixed(
-                                             "core:hasTemporalCoverage".to_string(),
-                                         )),
-                                         object: VarOrNodeOrLiteral::Variable("tcov".to_string()),
-                                     })),
-                                         WhereCondition::Simple(TriplePattern(msg::TriplePattern {
-                                             subject: VarOrNode::Node(NamedNode(Prefixed("metadata-dataset:80b1f84e-86dc-4730-b54f-701ad9b1888a".to_string()))),
-                                             predicate: VarOrNamedNode::NamedNode(Prefixed(
-                                                 "core:hasInformations".to_string(),
-                                             )),
-                                             object: VarOrNodeOrLiteral::Variable("info".to_string()),
-                                         })),
-                                                   WhereCondition::Simple(TriplePattern(msg::TriplePattern {
-                                                       subject: VarOrNode::Variable("tcov".to_string()),
-                                                       predicate: VarOrNamedNode::Variable("tcov_p".to_string()),
-                                                       object: VarOrNodeOrLiteral::Variable("tcov_o".to_string()),
-                                                   })),
-                                         WhereCondition::Simple(TriplePattern(msg::TriplePattern {
-                                             subject: VarOrNode::Variable("info".to_string()),
-                                             predicate: VarOrNamedNode::Variable("info_p".to_string()),
-                                             object: VarOrNodeOrLiteral::Variable("info_o".to_string()),
-                                         }))
-                                     ],
-                                 },
-                                 format: Some(DataFormat::NTriples),
-                             },
-                             ConstructResponse {
-                                 format: DataFormat::NTriples,
-                                 data: Binary::from(
-                                     "<a0> <https://my-ns/predicate/tcov> <b0> .\n<a0> <https://my-ns/predicate/info> <b1> .\n<b0> <http://www.w3.org/1999/02/22-rdf-syntax-ns#type> <http://www.w3.org/2002/07/owl#NamedIndividual> .\n<b1> <https://ontology.okp4.space/core/hasInformation> \"this is a dataset\" .\n<a0> <https://my-ns/predicate/tcov> <b0> .\n<a0> <https://my-ns/predicate/info> <b1> .\n<b0> <http://www.w3.org/1999/02/22-rdf-syntax-ns#type> <https://ontology.okp4.space/core/Period> .\n<b1> <https://ontology.okp4.space/core/hasInformation> \"this is a dataset\" .\n<a0> <https://my-ns/predicate/tcov> <b0> .\n<a0> <https://my-ns/predicate/info> <b1> .\n<b0> <https://ontology.okp4.space/core/hasStartDate> \"2022-01-01T00:00:00+00:00\"^^<http://www.w3.org/2001/XMLSchema#dateTime> .\n<b1> <https://ontology.okp4.space/core/hasInformation> \"this is a dataset\" .\n".to_string().as_bytes().to_vec()),
-                             },
-                         ),
+                            msg::TripleConstructTemplate {
+                                subject: VarOrNode::Variable("info".to_string()),
+                                predicate: VarOrNamedNode::Variable("info_p".to_string()),
+                                object: VarOrNodeOrLiteral::Variable("info_o".to_string()),
+                            }
+                        ],
+                        r#where: vec![
+                            WhereCondition::Simple(TriplePattern(msg::TriplePattern {
+                                subject: VarOrNode::Node(NamedNode(Prefixed("metadata-dataset:80b1f84e-86dc-4730-b54f-701ad9b1888a".to_string()))),
+                                predicate: VarOrNamedNode::NamedNode(Prefixed(
+                                    "core:hasTemporalCoverage".to_string(),
+                                )),
+                                object: VarOrNodeOrLiteral::Variable("tcov".to_string()),
+                            })),
+                            WhereCondition::Simple(TriplePattern(msg::TriplePattern {
+                                subject: VarOrNode::Node(NamedNode(Prefixed("metadata-dataset:80b1f84e-86dc-4730-b54f-701ad9b1888a".to_string()))),
+                                predicate: VarOrNamedNode::NamedNode(Prefixed(
+                                    "core:hasInformations".to_string(),
+                                )),
+                                object: VarOrNodeOrLiteral::Variable("info".to_string()),
+                            })),
+                            WhereCondition::Simple(TriplePattern(msg::TriplePattern {
+                                subject: VarOrNode::Variable("tcov".to_string()),
+                                predicate: VarOrNamedNode::Variable("tcov_p".to_string()),
+                                object: VarOrNodeOrLiteral::Variable("tcov_o".to_string()),
+                            })),
+                            WhereCondition::Simple(TriplePattern(msg::TriplePattern {
+                                subject: VarOrNode::Variable("info".to_string()),
+                                predicate: VarOrNamedNode::Variable("info_p".to_string()),
+                                object: VarOrNodeOrLiteral::Variable("info_o".to_string()),
+                            }))
+                        ],
+                    },
+                    format: Some(DataFormat::NTriples),
+                },
+                ConstructResponse {
+                    format: DataFormat::NTriples,
+                    data: Binary::from(
+                        "<a0> <https://my-ns/predicate/tcov> <b0> .\n<a0> <https://my-ns/predicate/info> <b1> .\n<b0> <http://www.w3.org/1999/02/22-rdf-syntax-ns#type> <http://www.w3.org/2002/07/owl#NamedIndividual> .\n<b1> <https://ontology.okp4.space/core/hasInformation> \"this is a dataset\" .\n<a0> <https://my-ns/predicate/tcov> <b0> .\n<a0> <https://my-ns/predicate/info> <b1> .\n<b0> <http://www.w3.org/1999/02/22-rdf-syntax-ns#type> <https://ontology.okp4.space/core/Period> .\n<b1> <https://ontology.okp4.space/core/hasInformation> \"this is a dataset\" .\n<a0> <https://my-ns/predicate/tcov> <b0> .\n<a0> <https://my-ns/predicate/info> <b1> .\n<b0> <https://ontology.okp4.space/core/hasStartDate> \"2022-01-01T00:00:00+00:00\"^^<http://www.w3.org/2001/XMLSchema#dateTime> .\n<b1> <https://ontology.okp4.space/core/hasInformation> \"this is a dataset\" .\n".to_string().as_bytes().to_vec()),
+                },
+            ),
         ];
 
         for (data, q, expected) in cases {

--- a/contracts/okp4-cognitarium/src/msg.rs
+++ b/contracts/okp4-cognitarium/src/msg.rs
@@ -528,7 +528,7 @@ pub struct TriplePattern {
     /// The subject of the triple pattern.
     pub subject: VarOrNode,
     /// The predicate of the triple pattern.
-    pub predicate: VarOrNode,
+    pub predicate: VarOrNamedNode,
     /// The object of the triple pattern.
     pub object: VarOrNodeOrLiteral,
 }

--- a/contracts/okp4-cognitarium/src/msg.rs
+++ b/contracts/okp4-cognitarium/src/msg.rs
@@ -497,7 +497,7 @@ pub trait HasVariables {
 
 impl<T: HasVariables> HasVariables for Vec<T> {
     fn variables(&self) -> HashSet<String> {
-        self.iter().flat_map(|t| t.variables()).collect()
+        self.iter().flat_map(HasVariables::variables).collect()
     }
 }
 
@@ -578,7 +578,7 @@ mod var_util {
         maybe_vars
             .iter()
             .copied()
-            .filter_map(|maybe_var| maybe_var)
+            .flatten()
             .map(str::to_string)
             .collect()
     }

--- a/contracts/okp4-cognitarium/src/msg.rs
+++ b/contracts/okp4-cognitarium/src/msg.rs
@@ -51,7 +51,7 @@ pub enum ExecuteMsg {
     ///   "where": [
     ///     { "simple": { "triplePattern": {
     ///         "subject": { "variable": "s" },
-    ///         "predicate": { "node": { "namedNode": {"prefixed": "foaf:givenName"} } },
+    ///         "predicate": { "namedNode": {"prefixed": "foaf:givenName"} },
     ///         "object": { "literal": { "simple": "Myrddin" } }
     ///     } } },
     ///     { "simple": { "triplePattern": {

--- a/contracts/okp4-cognitarium/src/msg.rs
+++ b/contracts/okp4-cognitarium/src/msg.rs
@@ -68,6 +68,7 @@ pub enum ExecuteMsg {
         /// The prefixes used in the operation.
         prefixes: Vec<Prefix>,
         /// Specifies the specific triple templates to delete.
+        /// If nothing is provided, the patterns from the `where` clause are used for deletion.
         delete: Vec<TripleDeleteTemplate>,
         /// Defines the patterns that data (RDF triples) should match in order for it to be
         /// considered for deletion.
@@ -434,6 +435,7 @@ pub struct ConstructQuery {
     /// The prefixes used in the query.
     pub prefixes: Vec<Prefix>,
     /// The triples to construct.
+    /// If nothing is provided, the patterns from the `where` clause are used for construction.
     pub construct: Vec<TripleConstructTemplate>,
     /// The WHERE clause.
     /// This clause is used to specify the triples to construct using variable bindings.

--- a/contracts/okp4-cognitarium/src/querier/engine.rs
+++ b/contracts/okp4-cognitarium/src/querier/engine.rs
@@ -624,7 +624,7 @@ impl TripleTemplate {
         F: Fn(&ResolvedVariable) -> Option<T>,
     {
         match term {
-            Left(p) => StdResult::Ok(Some(p.clone())),
+            Left(p) => Ok(Some(p.clone())),
             Right(key) => vars.get(key).map(from_var).ok_or_else(|| {
                 StdError::generic_err(format!("Unbound {:?} variable: {:?}", term_name, key))
             }),
@@ -761,17 +761,17 @@ impl AtomTemplate {
     ) -> StdResult<AtomTemplate> {
         Ok(Self {
             subject: match s_tpl {
-                VarOrNode::Variable(key) => Right(key.clone()),
-                VarOrNode::Node(n) => Left((n.clone(), prefixes).try_into()?),
+                VarOrNode::Variable(key) => Right(key),
+                VarOrNode::Node(n) => Left((n, prefixes).try_into()?),
             },
             property: match p_tpl {
                 VarOrNamedNode::Variable(key) => Right(key),
                 VarOrNamedNode::NamedNode(iri) => Left((iri, prefixes).try_into()?),
             },
             value: match o_tpl {
-                VarOrNodeOrLiteral::Variable(key) => Right(key.clone()),
-                VarOrNodeOrLiteral::Node(n) => Left((n.clone(), prefixes).try_into()?),
-                VarOrNodeOrLiteral::Literal(l) => Left((l.clone(), prefixes).try_into()?),
+                VarOrNodeOrLiteral::Variable(key) => Right(key),
+                VarOrNodeOrLiteral::Node(n) => Left((n, prefixes).try_into()?),
+                VarOrNodeOrLiteral::Literal(l) => Left((l, prefixes).try_into()?),
             },
         })
     }

--- a/contracts/okp4-cognitarium/src/querier/engine.rs
+++ b/contracts/okp4-cognitarium/src/querier/engine.rs
@@ -1,8 +1,8 @@
 use crate::msg::{
-    Node, SelectItem, TriplePattern, VarOrNamedNode, VarOrNamedNodeOrLiteral, VarOrNode,
+    SelectItem, TriplePattern, VarOrNamedNode, VarOrNamedNodeOrLiteral, VarOrNode,
     VarOrNodeOrLiteral,
 };
-use crate::querier::mapper::{iri_as_node, literal_as_object, node_as_predicate};
+use crate::querier::mapper::{iri_as_node, literal_as_object};
 use crate::querier::plan::{PatternValue, QueryNode, QueryPlan};
 use crate::querier::variable::{ResolvedVariable, ResolvedVariables};
 use crate::rdf::Atom;

--- a/contracts/okp4-cognitarium/src/querier/mapper.rs
+++ b/contracts/okp4-cognitarium/src/querier/mapper.rs
@@ -1,23 +1,9 @@
-use crate::msg::{Literal, Node, IRI};
+use crate::msg::{Literal, IRI};
 use crate::state;
-use crate::state::{NamespaceResolver, Object, Predicate};
-use cosmwasm_std::{StdError, StdResult, Storage};
+use crate::state::{NamespaceResolver, Object};
+use cosmwasm_std::{StdResult, Storage};
 use okp4_rdf::uri::{expand_uri, explode_iri};
 use std::collections::HashMap;
-
-pub fn node_as_predicate(
-    ns_resolver: &mut NamespaceResolver,
-    storage: &dyn Storage,
-    prefixes: &HashMap<String, String>,
-    node: Node,
-) -> StdResult<Predicate> {
-    match node {
-        Node::NamedNode(iri) => iri_as_node(ns_resolver, storage, prefixes, iri),
-        Node::BlankNode(_) => Err(StdError::generic_err(
-            "Predicate pattern must be a named node",
-        )),
-    }
-}
 
 pub fn literal_as_object(
     ns_resolver: &mut NamespaceResolver,

--- a/contracts/okp4-cognitarium/src/querier/mapper.rs
+++ b/contracts/okp4-cognitarium/src/querier/mapper.rs
@@ -1,21 +1,9 @@
 use crate::msg::{Literal, Node, IRI};
 use crate::state;
-use crate::state::{NamespaceResolver, Object, Predicate, Subject};
+use crate::state::{NamespaceResolver, Object, Predicate};
 use cosmwasm_std::{StdError, StdResult, Storage};
 use okp4_rdf::uri::{expand_uri, explode_iri};
 use std::collections::HashMap;
-
-pub fn node_as_subject(
-    ns_resolver: &mut NamespaceResolver,
-    storage: &dyn Storage,
-    prefixes: &HashMap<String, String>,
-    node: Node,
-) -> StdResult<Subject> {
-    Ok(match node {
-        Node::NamedNode(iri) => Subject::Named(iri_as_node(ns_resolver, storage, prefixes, iri)?),
-        Node::BlankNode(blank) => Subject::Blank(blank),
-    })
-}
 
 pub fn node_as_predicate(
     ns_resolver: &mut NamespaceResolver,
@@ -29,18 +17,6 @@ pub fn node_as_predicate(
             "Predicate pattern must be a named node",
         )),
     }
-}
-
-pub fn node_as_object(
-    ns_resolver: &mut NamespaceResolver,
-    storage: &dyn Storage,
-    prefixes: &HashMap<String, String>,
-    node: Node,
-) -> StdResult<Object> {
-    Ok(match node {
-        Node::NamedNode(iri) => Object::Named(iri_as_node(ns_resolver, storage, prefixes, iri)?),
-        Node::BlankNode(blank) => Object::Blank(blank),
-    })
 }
 
 pub fn literal_as_object(

--- a/contracts/okp4-cognitarium/src/querier/mod.rs
+++ b/contracts/okp4-cognitarium/src/querier/mod.rs
@@ -6,3 +6,4 @@ mod variable;
 
 pub use engine::*;
 pub use plan_builder::*;
+pub use variable::ResolvedVariables;

--- a/contracts/okp4-cognitarium/src/querier/plan.rs
+++ b/contracts/okp4-cognitarium/src/querier/plan.rs
@@ -155,16 +155,14 @@ mod tests {
                         child: Box::new(QueryNode::ForLoopJoin {
                             left: Box::new(QueryNode::CartesianProductJoin {
                                 left: Box::new(QueryNode::TriplePattern {
-                                    subject: PatternValue::Constant(Subject::Blank(
-                                        "_".to_string(),
-                                    )),
-                                    predicate: PatternValue::Variable(4usize),
+                                    subject: PatternValue::BlankVariable(4usize),
+                                    predicate: PatternValue::Variable(5usize),
                                     object: PatternValue::Variable(0usize),
                                 }),
                                 right: Box::new(QueryNode::TriplePattern {
                                     subject: PatternValue::Variable(3usize),
                                     predicate: PatternValue::Variable(1usize),
-                                    object: PatternValue::Constant(Object::Blank("_".to_string())),
+                                    object: PatternValue::BlankVariable(4usize),
                                 }),
                             }),
                             right: Box::new(QueryNode::TriplePattern {
@@ -175,7 +173,7 @@ mod tests {
                         }),
                     }),
                 },
-                BTreeSet::from([0usize, 1usize, 2usize, 3usize, 4usize]),
+                BTreeSet::from([0usize, 1usize, 2usize, 3usize, 4usize, 5usize]),
             ),
         ];
 

--- a/contracts/okp4-cognitarium/src/querier/plan.rs
+++ b/contracts/okp4-cognitarium/src/querier/plan.rs
@@ -22,18 +22,16 @@ pub enum PlanVariable {
 impl QueryPlan {
     /// Resolve the index corresponding to the variable name, if not attached to a blank node.
     pub fn get_var_index(&self, var_name: &str) -> Option<usize> {
-        self.variables
-            .iter()
-            .enumerate()
-            .find_map(|(index, it)| match it {
-                PlanVariable::Basic(name) => {
-                    if name == var_name {
-                        return Some(index);
-                    }
-                    None
-                }
-                PlanVariable::BlankNode(_) => None,
-            })
+        self.variables.iter().enumerate().find_map(|(index, it)| {
+            matches!(it, PlanVariable::Basic(name) if name == var_name).then_some(index)
+        })
+    }
+
+    /// Resolve the index corresponding to blank node name.
+    pub fn get_bnode_index(&self, bnode_name: &str) -> Option<usize> {
+        self.variables.iter().enumerate().find_map(|(index, it)| {
+            matches!(it, PlanVariable::BlankNode(name) if name == bnode_name).then_some(index)
+        })
     }
 }
 

--- a/contracts/okp4-cognitarium/src/querier/plan_builder.rs
+++ b/contracts/okp4-cognitarium/src/querier/plan_builder.rs
@@ -5,7 +5,7 @@ use crate::msg::{
 use crate::querier::mapper::{iri_as_node, literal_as_object};
 use crate::querier::plan::{PatternValue, PlanVariable, QueryNode, QueryPlan};
 use crate::state::{HasCachedNamespaces, Namespace, NamespaceResolver, Object, Predicate, Subject};
-use cosmwasm_std::{StdError, StdResult, Storage};
+use cosmwasm_std::{StdResult, Storage};
 use std::collections::HashMap;
 
 pub struct PlanBuilder<'a> {
@@ -480,7 +480,12 @@ mod test {
                 None,
                 None,
                 vec![],
-                Err(StdError::generic_err("Empty basic graph pattern")),
+                Ok(QueryPlan {
+                    entrypoint: QueryNode::Noop {
+                        bound_variables: vec![],
+                    },
+                    variables: vec![],
+                }),
             ),
             (
                 None,

--- a/contracts/okp4-cognitarium/src/querier/variable.rs
+++ b/contracts/okp4-cognitarium/src/querier/variable.rs
@@ -17,7 +17,7 @@ impl ResolvedVariable {
             ResolvedVariable::Predicate(p) => Subject::Named(p.clone()),
             ResolvedVariable::Object(o) => match o {
                 Object::Named(node) => Subject::Named(node.clone()),
-                Object::Blank(node) => Subject::Blank(node.clone()),
+                Object::Blank(node) => Subject::Blank(*node),
                 Object::Literal(_) => None?,
             },
         })
@@ -42,7 +42,7 @@ impl ResolvedVariable {
         Some(match self {
             ResolvedVariable::Subject(s) => match s {
                 Subject::Named(node) => Object::Named(node.clone()),
-                Subject::Blank(node) => Object::Blank(node.clone()),
+                Subject::Blank(node) => Object::Blank(*node),
             },
             ResolvedVariable::Predicate(p) => Object::Named(p.clone()),
             ResolvedVariable::Object(o) => o.clone(),

--- a/contracts/okp4-cognitarium/src/querier/variable.rs
+++ b/contracts/okp4-cognitarium/src/querier/variable.rs
@@ -1,6 +1,7 @@
 use crate::msg::{Value, IRI};
 use crate::state::{Literal, Object, Predicate, Subject};
 use cosmwasm_std::StdResult;
+use okp4_rdf::normalize::IdentifierIssuer;
 
 #[derive(Eq, PartialEq, Debug, Clone)]
 pub enum ResolvedVariable {
@@ -48,7 +49,7 @@ impl ResolvedVariable {
         })
     }
 
-    pub fn as_value<F>(&self, ns_fn: &mut F) -> StdResult<Value>
+    pub fn as_value<F>(&self, ns_fn: &mut F, id_issuer: &mut IdentifierIssuer) -> StdResult<Value>
     where
         F: FnMut(u128) -> StdResult<String>,
     {
@@ -58,7 +59,7 @@ impl ResolvedVariable {
                     value: IRI::Full(iri),
                 })?,
                 Subject::Blank(blank) => Value::BlankNode {
-                    value: blank.to_string(),
+                    value: id_issuer.get_str_or_issue(blank.to_string()),
                 },
             },
             ResolvedVariable::Predicate(predicate) => {
@@ -71,7 +72,7 @@ impl ResolvedVariable {
                     value: IRI::Full(named.as_iri(ns_fn)?),
                 },
                 Object::Blank(blank) => Value::BlankNode {
-                    value: blank.to_string(),
+                    value: id_issuer.get_str_or_issue(blank.to_string()),
                 },
                 Object::Literal(literal) => match literal {
                     Literal::Simple { value } => Value::Literal {
@@ -155,9 +156,9 @@ mod tests {
     fn conversions() {
         let cases: Vec<(Option<Subject>, Option<Predicate>, Option<Object>)> = vec![
             (
-                Some(Subject::Blank("_".to_string())),
+                Some(Subject::Blank(0u128)),
                 None,
-                Some(Object::Blank("_".to_string())),
+                Some(Object::Blank(0u128)),
             ),
             (
                 Some(Subject::Named(Node {
@@ -226,9 +227,9 @@ mod tests {
                 }),
             ),
             (
-                ResolvedVariable::Subject(Subject::Blank("_".to_string())),
+                ResolvedVariable::Subject(Subject::Blank(0u128)),
                 Ok(Value::BlankNode {
-                    value: "_".to_string(),
+                    value: "b0".to_string(),
                 }),
             ),
             (
@@ -250,9 +251,9 @@ mod tests {
                 }),
             ),
             (
-                ResolvedVariable::Object(Object::Blank("_".to_string())),
+                ResolvedVariable::Object(Object::Blank(0u128)),
                 Ok(Value::BlankNode {
-                    value: "_".to_string(),
+                    value: "b0".to_string(),
                 }),
             ),
             (
@@ -292,61 +293,38 @@ mod tests {
             ),
         ];
 
+        let mut id_issuer = IdentifierIssuer::new("b", 0u128);
         for (var, expected) in cases {
-            assert_eq!(var.as_value(&mut ns), expected)
+            assert_eq!(var.as_value(&mut ns, &mut id_issuer), expected)
         }
     }
 
     #[test]
     fn merged_variables() {
         let mut vars1 = ResolvedVariables::with_capacity(3);
-        vars1.merge_index(
-            0,
-            ResolvedVariable::Object(Object::Blank("foo".to_string())),
-        );
-        vars1.merge_index(
-            2,
-            ResolvedVariable::Object(Object::Blank("bar".to_string())),
-        );
+        vars1.merge_index(0, ResolvedVariable::Object(Object::Blank(0u128)));
+        vars1.merge_index(2, ResolvedVariable::Object(Object::Blank(1u128)));
 
         let mut vars2 = ResolvedVariables::with_capacity(3);
-        vars2.merge_index(
-            1,
-            ResolvedVariable::Object(Object::Blank("pop".to_string())),
-        );
-        vars2.merge_index(
-            2,
-            ResolvedVariable::Object(Object::Blank("bar".to_string())),
-        );
+        vars2.merge_index(1, ResolvedVariable::Object(Object::Blank(2u128)));
+        vars2.merge_index(2, ResolvedVariable::Object(Object::Blank(1u128)));
 
         assert_eq!(
             vars2.get(1),
-            &Some(ResolvedVariable::Object(Object::Blank("pop".to_string())))
+            &Some(ResolvedVariable::Object(Object::Blank(2u128)))
         );
         assert_eq!(vars1.get(1), &None);
 
         let mut expected_result = ResolvedVariables::with_capacity(3);
-        expected_result.merge_index(
-            0,
-            ResolvedVariable::Object(Object::Blank("foo".to_string())),
-        );
-        expected_result.merge_index(
-            1,
-            ResolvedVariable::Object(Object::Blank("pop".to_string())),
-        );
-        expected_result.merge_index(
-            2,
-            ResolvedVariable::Object(Object::Blank("bar".to_string())),
-        );
+        expected_result.merge_index(0, ResolvedVariable::Object(Object::Blank(0u128)));
+        expected_result.merge_index(1, ResolvedVariable::Object(Object::Blank(2u128)));
+        expected_result.merge_index(2, ResolvedVariable::Object(Object::Blank(1u128)));
 
         let result = vars1.merge_with(&vars2);
         assert_eq!(result, Some(expected_result));
 
         let mut vars3 = ResolvedVariables::with_capacity(3);
-        vars3.merge_index(
-            1,
-            ResolvedVariable::Object(Object::Blank("pop".to_string())),
-        );
+        vars3.merge_index(1, ResolvedVariable::Object(Object::Blank(2u128)));
         vars3.merge_index(
             2,
             ResolvedVariable::Predicate(Node {

--- a/contracts/okp4-cognitarium/src/rdf/mapper.rs
+++ b/contracts/okp4-cognitarium/src/rdf/mapper.rs
@@ -20,20 +20,15 @@ impl TryFrom<(msg::Node, &HashMap<String, String>)> for Subject {
     }
 }
 
-impl TryFrom<(msg::Node, &HashMap<String, String>)> for Property {
+impl TryFrom<(msg::IRI, &HashMap<String, String>)> for Property {
     type Error = StdError;
 
     fn try_from(
-        (node, prefixes): (msg::Node, &HashMap<String, String>),
+        (iri, prefixes): (msg::IRI, &HashMap<String, String>),
     ) -> Result<Self, Self::Error> {
-        match node {
-            msg::Node::NamedNode(msg::IRI::Full(uri)) => Ok(Property(uri)),
-            msg::Node::NamedNode(msg::IRI::Prefixed(curie)) => {
-                Ok(Property(expand_uri(&curie, prefixes)?))
-            }
-            _ => Err(StdError::generic_err(format!(
-                "Unsupported predicate node: {node:?}. Expected URI"
-            ))),
+        match iri {
+            msg::IRI::Full(uri) => Ok(Property(uri)),
+            msg::IRI::Prefixed(curie) => Ok(Property(expand_uri(&curie, prefixes)?)),
         }
     }
 }

--- a/contracts/okp4-cognitarium/src/state/blank_nodes.rs
+++ b/contracts/okp4-cognitarium/src/state/blank_nodes.rs
@@ -1,0 +1,4 @@
+use cw_storage_plus::Item;
+
+/// A counter serving as blank node unique identifier generator.
+pub const BLANK_NODE_IDENTIFIER_COUNTER: Item<'_, u128> = Item::new("blank_node_key");

--- a/contracts/okp4-cognitarium/src/state/mod.rs
+++ b/contracts/okp4-cognitarium/src/state/mod.rs
@@ -1,7 +1,9 @@
+mod blank_nodes;
 mod namespaces;
 mod store;
 mod triples;
 
+pub use blank_nodes::*;
 pub use namespaces::*;
 pub use store::*;
 pub use triples::*;

--- a/contracts/okp4-cognitarium/src/state/triples.rs
+++ b/contracts/okp4-cognitarium/src/state/triples.rs
@@ -77,7 +77,7 @@ impl Subject {
                 key
             }
             Subject::Blank(n) => {
-                let val = n.as_bytes();
+                let val = n.to_be_bytes();
                 let mut key: Vec<u8> = Vec::with_capacity(val.len() + 1);
                 key.push(b'b');
                 key.extend(val);
@@ -108,7 +108,7 @@ impl Object {
                     .update(n.value.as_bytes());
             }
             Object::Blank(n) => {
-                hasher.update(&[b'b']).update(n.as_bytes());
+                hasher.update(&[b'b']).update(n.to_be_bytes().as_slice());
             }
             Object::Literal(l) => {
                 hasher.update(&[b'l']);
@@ -131,7 +131,8 @@ impl Object {
     }
 }
 
-pub type BlankNode = String;
+pub const BLANK_NODE_SIZE: usize = 16usize;
+pub type BlankNode = u128;
 
 #[derive(Serialize, Deserialize, Clone, Debug, PartialEq, Eq)]
 pub struct Node {
@@ -191,10 +192,7 @@ mod test {
                     value: "val".to_string(),
                 }),
             ),
-            (
-                Object::Blank("val1".to_string()),
-                Object::Blank("val2".to_string()),
-            ),
+            (Object::Blank(0u128), Object::Blank(1u128)),
             (
                 Object::Literal(Literal::Simple {
                     value: "val1".to_string(),
@@ -272,7 +270,7 @@ mod test {
                 }),
             ),
             (
-                Object::Blank("val".to_string()),
+                Object::Blank(0u128),
                 Object::Literal(Literal::Simple {
                     value: "val".to_string(),
                 }),

--- a/contracts/okp4-dataverse/src/contract.rs
+++ b/contracts/okp4-dataverse/src/contract.rs
@@ -131,8 +131,8 @@ mod tests {
     };
     use okp4_cognitarium::msg::{
         DataFormat, Head, Node, Results, SelectItem, SelectQuery, SelectResponse,
-        SimpleWhereCondition, TriplePattern, Value, VarOrNode, VarOrNodeOrLiteral, WhereCondition,
-        IRI,
+        SimpleWhereCondition, TriplePattern, Value, VarOrNamedNode, VarOrNode, VarOrNodeOrLiteral,
+        WhereCondition, IRI,
     };
     use std::collections::BTreeMap;
 
@@ -220,7 +220,7 @@ mod tests {
                                     subject: VarOrNode::Node(Node::NamedNode(IRI::Full(
                                         "http://example.edu/credentials/3732".to_string(),
                                     ))),
-                                    predicate: VarOrNode::Variable("p".to_string()),
+                                    predicate: VarOrNamedNode::Variable("p".to_string()),
                                     object: VarOrNodeOrLiteral::Variable("o".to_string()),
                                 })
                             )],

--- a/contracts/okp4-dataverse/src/registrar/registry.rs
+++ b/contracts/okp4-dataverse/src/registrar/registry.rs
@@ -4,8 +4,8 @@ use crate::state::DATAVERSE;
 use crate::ContractError;
 use cosmwasm_std::{DepsMut, StdResult, Storage, WasmMsg};
 use okp4_cognitarium::msg::{
-    DataFormat, Node, SelectItem, SelectQuery, SimpleWhereCondition, TriplePattern, VarOrNode,
-    VarOrNodeOrLiteral, WhereCondition, IRI,
+    DataFormat, Node, SelectItem, SelectQuery, SimpleWhereCondition, TriplePattern, VarOrNamedNode,
+    VarOrNode, VarOrNodeOrLiteral, WhereCondition, IRI,
 };
 use okp4_cognitarium_client::CognitariumClient;
 
@@ -42,7 +42,7 @@ impl ClaimRegistrar {
                         subject: VarOrNode::Node(Node::NamedNode(IRI::Full(
                             credential.id.to_string(),
                         ))),
-                        predicate: VarOrNode::Variable("p".to_string()),
+                        predicate: VarOrNamedNode::Variable("p".to_string()),
                         object: VarOrNodeOrLiteral::Variable("o".to_string()),
                     },
                 ))],

--- a/docs/okp4-cognitarium.md
+++ b/docs/okp4-cognitarium.md
@@ -415,12 +415,12 @@ Example: `json { "prefixes": [ { "prefix": "foaf", "namespace": "http://xmlns.co
 
 Only the smart contract owner (i.e. the address who instantiated it) is authorized to perform this action.
 
-| parameter              | description                                                                                                                                                                 |
-| ---------------------- | --------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
-| `delete_data`          | _(Required.) _ **object**.                                                                                                                                                  |
-| `delete_data.delete`   | _(Required.) _ **Array&lt;[TripleDeleteTemplate](#tripledeletetemplate)&gt;**. Specifies the specific triple templates to delete.                                           |
-| `delete_data.prefixes` | _(Required.) _ **Array&lt;[Prefix](#prefix)&gt;**. The prefixes used in the operation.                                                                                      |
-| `delete_data.where`    | _(Required.) _ **Array&lt;[WhereCondition](#wherecondition)&gt;**. Defines the patterns that data (RDF triples) should match in order for it to be considered for deletion. |
+| parameter              | description                                                                                                                                                                                                           |
+| ---------------------- | --------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
+| `delete_data`          | _(Required.) _ **object**.                                                                                                                                                                                            |
+| `delete_data.delete`   | _(Required.) _ **Array&lt;[TripleDeleteTemplate](#tripledeletetemplate)&gt;**. Specifies the specific triple templates to delete. If nothing is provided, the patterns from the `where` clause are used for deletion. |
+| `delete_data.prefixes` | _(Required.) _ **Array&lt;[Prefix](#prefix)&gt;**. The prefixes used in the operation.                                                                                                                                |
+| `delete_data.where`    | _(Required.) _ **Array&lt;[WhereCondition](#wherecondition)&gt;**. Defines the patterns that data (RDF triples) should match in order for it to be considered for deletion.                                           |
 
 ## QueryMsg
 
@@ -536,11 +536,11 @@ An RDF [blank node](https://www.w3.org/TR/rdf11-concepts/#dfn-blank-node).
 
 Represents a CONSTRUCT query over the triple store, allowing to retrieve a set of triples serialized in a specific format.
 
-| property    | description                                                                                                                                                           |
-| ----------- | --------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
-| `construct` | _(Required.) _ **Array&lt;[TripleConstructTemplate](#tripleconstructtemplate)&gt;**. The triples to construct.                                                        |
-| `prefixes`  | _(Required.) _ **Array&lt;[Prefix](#prefix)&gt;**. The prefixes used in the query.                                                                                    |
-| `where`     | _(Required.) _ **Array&lt;[WhereCondition](#wherecondition)&gt;**. The WHERE clause. This clause is used to specify the triples to construct using variable bindings. |
+| property    | description                                                                                                                                                                                            |
+| ----------- | ------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------ |
+| `construct` | _(Required.) _ **Array&lt;[TripleConstructTemplate](#tripleconstructtemplate)&gt;**. The triples to construct. If nothing is provided, the patterns from the `where` clause are used for construction. |
+| `prefixes`  | _(Required.) _ **Array&lt;[Prefix](#prefix)&gt;**. The prefixes used in the query.                                                                                                                     |
+| `where`     | _(Required.) _ **Array&lt;[WhereCondition](#wherecondition)&gt;**. The WHERE clause. This clause is used to specify the triples to construct using variable bindings.                                  |
 
 ### DataFormat
 
@@ -876,4 +876,4 @@ Represents a condition in a [WhereClause].
 
 ---
 
-_Rendered by [Fadroma](https://fadroma.tech) ([@fadroma/schema 1.1.0](https://www.npmjs.com/package/@fadroma/schema)) from `okp4-cognitarium.json` (`cd4c70c82335248d`)_
+_Rendered by [Fadroma](https://fadroma.tech) ([@fadroma/schema 1.1.0](https://www.npmjs.com/package/@fadroma/schema)) from `okp4-cognitarium.json` (`7aa73b0502a6138b`)_

--- a/docs/okp4-cognitarium.md
+++ b/docs/okp4-cognitarium.md
@@ -411,16 +411,16 @@ Only the smart contract owner (i.e. the address who instantiated it) is authoriz
 
 Delete the data (RDF triples) from the store matching the patterns defined by the provided query. For non-existing triples it acts as no-op.
 
-Example: `json { "prefixes": [ { "prefix": "foaf", "namespace": "http://xmlns.com/foaf/0.1/" } ], "delete": [ { "subject": { "variable": "s" }, "predicate": { "variable": "p" }, "object": { "variable": "o" } } ], "where": [ { "simple": { "triplePattern": { "subject": { "variable": "s" }, "predicate": { "node": { "namedNode": {"prefixed": "foaf:givenName"} } }, "object": { "literal": { "simple": "Myrddin" } } } } }, { "simple": { "triplePattern": { "subject": { "variable": "s" }, "predicate": { "variable": "p" }, "object": { "variable": "o" } } } } ] `
+Example: `json { "prefixes": [ { "prefix": "foaf", "namespace": "http://xmlns.com/foaf/0.1/" } ], "delete": [ { "subject": { "variable": "s" }, "predicate": { "variable": "p" }, "object": { "variable": "o" } } ], "where": [ { "simple": { "triplePattern": { "subject": { "variable": "s" }, "predicate": { "namedNode": {"prefixed": "foaf:givenName"} }, "object": { "literal": { "simple": "Myrddin" } } } } }, { "simple": { "triplePattern": { "subject": { "variable": "s" }, "predicate": { "variable": "p" }, "object": { "variable": "o" } } } } ] `
 
 Only the smart contract owner (i.e. the address who instantiated it) is authorized to perform this action.
 
-| parameter              | description                                                                                                                                                                                            |
-| ---------------------- | ------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------ |
-| `delete_data`          | _(Required.) _ **object**.                                                                                                                                                                             |
-| `delete_data.delete`   | _(Required.) _ **Array&lt;[TriplePattern](#triplepattern)&gt;**. Specifies the specific triple patterns to delete. If nothing is provided, the patterns from the `where` clause are used for deletion. |
-| `delete_data.prefixes` | _(Required.) _ **Array&lt;[Prefix](#prefix)&gt;**. The prefixes used in the operation.                                                                                                                 |
-| `delete_data.where`    | _(Required.) _ **Array&lt;[WhereCondition](#wherecondition)&gt;**. Defines the patterns that data (RDF triples) should match in order for it to be considered for deletion.                            |
+| parameter              | description                                                                                                                                                                 |
+| ---------------------- | --------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
+| `delete_data`          | _(Required.) _ **object**.                                                                                                                                                  |
+| `delete_data.delete`   | _(Required.) _ **Array&lt;[TripleDeleteTemplate](#tripledeletetemplate)&gt;**. Specifies the specific triple templates to delete.                                           |
+| `delete_data.prefixes` | _(Required.) _ **Array&lt;[Prefix](#prefix)&gt;**. The prefixes used in the operation.                                                                                      |
+| `delete_data.where`    | _(Required.) _ **Array&lt;[WhereCondition](#wherecondition)&gt;**. Defines the patterns that data (RDF triples) should match in order for it to be considered for deletion. |
 
 ## QueryMsg
 
@@ -536,11 +536,11 @@ An RDF [blank node](https://www.w3.org/TR/rdf11-concepts/#dfn-blank-node).
 
 Represents a CONSTRUCT query over the triple store, allowing to retrieve a set of triples serialized in a specific format.
 
-| property    | description                                                                                                                                                                        |
-| ----------- | ---------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
-| `construct` | _(Required.) _ **Array&lt;[TriplePattern](#triplepattern)&gt;**. The triples to construct. If nothing is provided, the patterns from the `where` clause are used for construction. |
-| `prefixes`  | _(Required.) _ **Array&lt;[Prefix](#prefix)&gt;**. The prefixes used in the query.                                                                                                 |
-| `where`     | _(Required.) _ **Array&lt;[WhereCondition](#wherecondition)&gt;**. The WHERE clause. This clause is used to specify the triples to construct using variable bindings.              |
+| property    | description                                                                                                                                                           |
+| ----------- | --------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
+| `construct` | _(Required.) _ **Array&lt;[TripleConstructTemplate](#tripleconstructtemplate)&gt;**. The triples to construct.                                                        |
+| `prefixes`  | _(Required.) _ **Array&lt;[Prefix](#prefix)&gt;**. The prefixes used in the query.                                                                                    |
+| `where`     | _(Required.) _ **Array&lt;[WhereCondition](#wherecondition)&gt;**. The WHERE clause. This clause is used to specify the triples to construct using variable bindings. |
 
 ### DataFormat
 
@@ -747,6 +747,26 @@ Contains usage information about the triple store.
 | `namespace_count` | _(Required.) _ **[Uint128](#uint128)**. The total number of IRI namespace present in the store. |
 | `triple_count`    | _(Required.) _ **[Uint128](#uint128)**. The total number of triple present in the store.        |
 
+### TripleConstructTemplate
+
+Represents a triple template to be forged for a construct query.
+
+| property    | description                                                                                     |
+| ----------- | ----------------------------------------------------------------------------------------------- |
+| `object`    | _(Required.) _ **[VarOrNodeOrLiteral](#varornodeorliteral)**. The object of the triple pattern. |
+| `predicate` | _(Required.) _ **[VarOrNamedNode](#varornamednode)**. The predicate of the triple pattern.      |
+| `subject`   | _(Required.) _ **[VarOrNode](#varornode)**. The subject of the triple pattern.                  |
+
+### TripleDeleteTemplate
+
+Represents a triple template to be deleted.
+
+| property    | description                                                                                               |
+| ----------- | --------------------------------------------------------------------------------------------------------- |
+| `object`    | _(Required.) _ **[VarOrNamedNodeOrLiteral](#varornamednodeorliteral)**. The object of the triple pattern. |
+| `predicate` | _(Required.) _ **[VarOrNamedNode](#varornamednode)**. The predicate of the triple pattern.                |
+| `subject`   | _(Required.) _ **[VarOrNamedNode](#varornamednode)**. The subject of the triple pattern.                  |
+
 ### TriplePattern
 
 Represents a triple pattern in a [SimpleWhereCondition].
@@ -754,7 +774,7 @@ Represents a triple pattern in a [SimpleWhereCondition].
 | property    | description                                                                                     |
 | ----------- | ----------------------------------------------------------------------------------------------- |
 | `object`    | _(Required.) _ **[VarOrNodeOrLiteral](#varornodeorliteral)**. The object of the triple pattern. |
-| `predicate` | _(Required.) _ **[VarOrNode](#varornode)**. The predicate of the triple pattern.                |
+| `predicate` | _(Required.) _ **[VarOrNamedNode](#varornamednode)**. The predicate of the triple pattern.      |
 | `subject`   | _(Required.) _ **[VarOrNode](#varornode)**. The subject of the triple pattern.                  |
 
 ### Turtle
@@ -809,6 +829,16 @@ Represents either a variable or a named node (IRI).
 | [Variable](#variable)   | **object**. A variable.                                                  |
 | [NamedNode](#namednode) | **object**. An RDF [IRI](https://www.w3.org/TR/rdf11-concepts/#dfn-iri). |
 
+### VarOrNamedNodeOrLiteral
+
+Represents either a variable, a named node or a literal.
+
+| variant                 | description                                                                                                                                        |
+| ----------------------- | -------------------------------------------------------------------------------------------------------------------------------------------------- |
+| [Variable](#variable)   | **object**. A variable.                                                                                                                            |
+| [NamedNode](#namednode) | **object**. An RDF [IRI](https://www.w3.org/TR/rdf11-concepts/#dfn-iri).                                                                           |
+| [Literal](#literal)     | **object**. An RDF [literal](https://www.w3.org/TR/rdf11-concepts/#dfn-literal), i.e. a simple literal, a language-tagged string or a typed value. |
+
 ### VarOrNode
 
 Represents either a variable or a node.
@@ -846,4 +876,4 @@ Represents a condition in a [WhereClause].
 
 ---
 
-_Rendered by [Fadroma](https://fadroma.tech) ([@fadroma/schema 1.1.0](https://www.npmjs.com/package/@fadroma/schema)) from `okp4-cognitarium.json` (`b3bea598ea8fda42`)_
+_Rendered by [Fadroma](https://fadroma.tech) ([@fadroma/schema 1.1.0](https://www.npmjs.com/package/@fadroma/schema)) from `okp4-cognitarium.json` (`cd4c70c82335248d`)_


### PR DESCRIPTION
Closes #434 
Closes #494 

Primarily intended to implement changes discussed in the issues mentioned just above: use internal identifiers for blank to avoid conflicts across insertions, and expose blank nodes in queries as ephemeral and generated identifiers. The impacts being structural the changes present in this PR ended up to be huge, I'll try to explain them.

## Blank nodes identifiers

Internally the blank nodes are not persisted as `u128`, unicity being ensured by incrementing a counter, the `IdentifierIssuer` present in the `okp4-rdf` package has slightly been modified to ease this purpose.

When querying triples, to map back the blank nodes to an ephemeral identifier the `IdentifierIssuer` is also used, generating identifiers prefixed by `b` (e.g. `_:b0`, `_:b1`, etc...).

To avoid conflict with provided blank nodes in a `Construct`, those are renamed using the same strategy but with a different prefix: `a` (e.g. `_:a0`, `_:a1`, etc...).

## API changes

### `TriplePattern`

The predicate part of `TriplePattern` in where clauses can not longer take a blank node as value, being impossible by spec, and in the state.

### `DeleteData`

The `delete` field containing triple patterns to be deleted has now its own type (i.e. `TripleDeleteTemplate` instead of `TriplePattern`), as in this selection we must not be able to selection blank nodes.

### `Construct`

For consistency purposes, and because "template" means construction conversely of "pattern" which denotes a filter, the `construct` field has now its own type (i.e. `TripleConstructTemplate`), this brings no breaking change as it is identical than `TriplePattern` in its content.

## Behaviour changes

Regarding the `DeleteData` execution message, to allow the deletion of provided triples the where clause is not mandatory as soon as the delete selection contains not variables.

## Performances

The operations of `DeleteData`, `Construct` and `Describe` doesn't rely anymore on the `QueryEngine::select`, instead of applying the templates on resolved solutions, we directly apply them on the resolved variables. This allow a needed fine control on the resolution, and brings better performances by removing a mapping layer.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Introduced new structures for more efficient triple pattern deletion and construction.
  - Added functionality for generating unique identifiers for blank nodes.
  - Enhanced query planning and execution with new methods and updated structures.
- **Refactor**
  - Simplified querier module by removing redundant functions and dependencies.
  - Updated various enums and structs across the system for better clarity and functionality.
  - Improved handling of blank nodes and identifiers in storage and RDF normalization.
- **Bug Fixes**
  - Corrected JSON examples and parameter descriptions in documentation to align with system changes.
- **Documentation**
  - Updated documentation to reflect new and updated entities, providing clearer examples and descriptions.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->