### PR TITLE
feat(dataverse): implements dataverse query

### DIFF
--- a/contracts/okp4-dataverse/src/msg.rs
+++ b/contracts/okp4-dataverse/src/msg.rs
@@ -1,5 +1,5 @@
 use cosmwasm_schema::{cw_serde, QueryResponses};
-use cosmwasm_std::{Binary, Uint128, Uint64};
+use cosmwasm_std::{Addr, Binary, Uint128, Uint64};
 
 /// `InstantiateMsg` is used to initialize a new instance of the dataverse.
 #[cw_serde]
@@ -189,4 +189,6 @@ pub enum QueryMsg {
 pub struct DataverseResponse {
     /// The name of the dataverse.
     pub name: String,
+    /// The cognitarium contract address.
+    pub triplestore_address: Addr,
 }

--- a/docs/okp4-dataverse.md
+++ b/docs/okp4-dataverse.md
@@ -135,11 +135,26 @@ Retrieves information about the current dataverse instance.
 
 DataverseResponse is the response of the Dataverse query.
 
-| property | description                                           |
-| -------- | ----------------------------------------------------- |
-| `name`   | _(Required.) _ **string**. The name of the dataverse. |
+| property              | description                                                         |
+| --------------------- | ------------------------------------------------------------------- |
+| `name`                | _(Required.) _ **string**. The name of the dataverse.               |
+| `triplestore_address` | _(Required.) _ **[Addr](#addr)**. The cognitarium contract address. |
 
 ## Definitions
+
+### Addr
+
+A human readable address.
+
+In Cosmos, this is typically bech32 encoded. But for multi-chain smart contracts no assumptions should be made other than being UTF-8 encoded and of reasonable length.
+
+This type represents a validated address. It can be created in the following ways 1. Use `Addr::unchecked(input)` 2. Use `let checked: Addr = deps.api.addr_validate(input)?` 3. Use `let checked: Addr = deps.api.addr_humanize(canonical_addr)?` 4. Deserialize from JSON. This must only be done from JSON that was validated before such as a contract's state. `Addr` must not be used in messages sent by the user because this would result in unvalidated instances.
+
+This type is immutable. If you really need to mutate it (Really? Are you sure?), create a mutable copy using `let mut mutable = Addr::to_string()` and operate on that `String` instance.
+
+| type        |
+| ----------- |
+| **string**. |
 
 ### Binary
 
@@ -223,5 +238,5 @@ let b = Uint64::from(70u32); assert_eq!(b.u64(), 70); ```
 
 ---
 
-*Rendered by [Fadroma](https://fadroma.tech) ([@fadroma/schema 1.1.0](https://www.npmjs.com/package/@fadroma/schema)) from `okp4-dataverse.json` (`c007ecd2b9eeb04a`)*
+*Rendered by [Fadroma](https://fadroma.tech) ([@fadroma/schema 1.1.0](https://www.npmjs.com/package/@fadroma/schema)) from `okp4-dataverse.json` (`bd9dd1798f1b3a0d`)*
 ````


### PR DESCRIPTION
Implements the `Dataverse` query to be able to retrieve name and cognitarium contract address.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
	- Enhanced data retrieval capabilities to include `Dataverse` data.
	- Added `triplestore_address` in `DataverseResponse` for improved data structuring.

- **Documentation**
	- Updated documentation to reflect new `triplestore_address` property and its significance.
	- Clarified the representation of validated addresses in the system.

- **Tests**
	- Implemented tests to ensure the reliability of new dataverse data retrieval functionalities.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->