### PR TITLE
Feat/support claim hierarchy

### DIFF
--- a/contracts/okp4-dataverse/src/registrar/rdf.rs
+++ b/contracts/okp4-dataverse/src/registrar/rdf.rs
@@ -243,6 +243,39 @@ _:c0 <https://w3id.org/okp4/ontology/vnext/schema/credential/digital-service/des
     }
 
     #[test]
+    fn proper_named_hierarchy_serialization() {
+        let owned_quads = testutil::read_test_quads("vc-claim-hierarchy.nq");
+        let dataset = Dataset::from(owned_quads.as_slice());
+        let vc = VerifiableCredential::try_from(&dataset).unwrap();
+        let dc = DataverseCredential::try_from((
+            Addr::unchecked("okp41072nc6egexqr2v6vpp7yxwm68plvqnkf6xsytf"),
+            &vc,
+        ))
+        .unwrap();
+
+        let expected = "<https://w3id.org/okp4/ontology/vnext/schema/credential/digital-service/description/72cab400-5bd6-4eb4-8605-a5ee8c1a45c9> <dataverse:credential#submitterAddress> \"okp41072nc6egexqr2v6vpp7yxwm68plvqnkf6xsytf\" .
+<https://w3id.org/okp4/ontology/vnext/schema/credential/digital-service/description/72cab400-5bd6-4eb4-8605-a5ee8c1a45c9> <dataverse:credential#issuer> <did:key:zQ3shs7auhJSmVJpiUbQWco6bxxEhSqWnVEPvaBHBRvBKw6Q3> .
+<https://w3id.org/okp4/ontology/vnext/schema/credential/digital-service/description/72cab400-5bd6-4eb4-8605-a5ee8c1a45c9> <dataverse:credential#type> <https://w3id.org/okp4/ontology/vnext/schema/credential/digital-service/description/DigitalServiceDescriptionCredential> .
+<https://w3id.org/okp4/ontology/vnext/schema/credential/digital-service/description/72cab400-5bd6-4eb4-8605-a5ee8c1a45c9> <dataverse:credential#validFrom> \"2024-01-22T00:00:00\"^^<http://www.w3.org/2001/XMLSchema#dateTime> .
+<https://w3id.org/okp4/ontology/vnext/schema/credential/digital-service/description/72cab400-5bd6-4eb4-8605-a5ee8c1a45c9> <dataverse:credential#subject> <did:key:zQ3shhb4SvzBRLbBonsvKb3WX6WoDeKWHpsXXXMhAJETqXAfB> .
+_:c0 <https://w3id.org/okp4/ontology/vnext/schema/credential/digital-service/description/hasCategory> <https://w3id.org/okp4/ontology/vnext/thesaurus/digital-service-category/Storage> .
+_:c0 <https://w3id.org/okp4/ontology/vnext/schema/credential/digital-service/description/hasTag> \"Cloud\" .
+_:c0 <test:claim#named-hierarchy> _:a0 .
+_:a0 <test:claim#nested-predicate> \"nested value\" .
+_:a0 <dataverse:claim#original-node> <test:named-link> .
+<https://w3id.org/okp4/ontology/vnext/schema/credential/digital-service/description/72cab400-5bd6-4eb4-8605-a5ee8c1a45c9> <dataverse:credential#claim> _:c0 .
+<https://w3id.org/okp4/ontology/vnext/schema/credential/digital-service/description/72cab400-5bd6-4eb4-8605-a5ee8c1a45c9> <dataverse:credential#validUntil> \"2025-01-22T00:00:00\"^^<http://www.w3.org/2001/XMLSchema#dateTime> .\n";
+
+        let serialization_res = dc.serialize(DataFormat::NQuads);
+        assert!(serialization_res.is_ok());
+
+        assert_eq!(
+            String::from_utf8(serialization_res.unwrap().0).unwrap(),
+            expected
+        );
+    }
+
+    #[test]
     fn serialize_reserved_predicates() {
         let owned_quads = testutil::read_test_quads("vc-unsupported-4.nq");
         let dataset = Dataset::from(owned_quads.as_slice());

--- a/contracts/okp4-dataverse/src/registrar/registry.rs
+++ b/contracts/okp4-dataverse/src/registrar/registry.rs
@@ -1,5 +1,4 @@
 use crate::registrar::credential::DataverseCredential;
-use crate::registrar::rdf::serialize;
 use crate::state::DATAVERSE;
 use crate::ContractError;
 use cosmwasm_std::{DepsMut, StdResult, Storage, WasmMsg};
@@ -58,7 +57,7 @@ impl ClaimRegistrar {
         self.triplestore
             .insert_data(
                 Some(Self::RDF_DATA_FORMAT),
-                serialize(credential, (&Self::RDF_DATA_FORMAT).into())?,
+                credential.serialize((&Self::RDF_DATA_FORMAT).into())?,
             )
             .map_err(ContractError::from)
     }

--- a/contracts/okp4-dataverse/testdata/vc-claim-hierarchy.nq
+++ b/contracts/okp4-dataverse/testdata/vc-claim-hierarchy.nq
@@ -1,0 +1,16 @@
+<did:key:zQ3shhb4SvzBRLbBonsvKb3WX6WoDeKWHpsXXXMhAJETqXAfB> <https://w3id.org/okp4/ontology/vnext/schema/credential/digital-service/description/hasCategory> <https://w3id.org/okp4/ontology/vnext/thesaurus/digital-service-category/Storage> .
+<did:key:zQ3shhb4SvzBRLbBonsvKb3WX6WoDeKWHpsXXXMhAJETqXAfB> <https://w3id.org/okp4/ontology/vnext/schema/credential/digital-service/description/hasTag> "Cloud" .
+<did:key:zQ3shhb4SvzBRLbBonsvKb3WX6WoDeKWHpsXXXMhAJETqXAfB> <test:claim#named-hierarchy> <test:named-link> .
+<test:named-link> <test:claim#nested-predicate> "nested value" .
+<https://w3id.org/okp4/ontology/vnext/schema/credential/digital-service/description/72cab400-5bd6-4eb4-8605-a5ee8c1a45c9> <http://www.w3.org/1999/02/22-rdf-syntax-ns#type> <https://w3id.org/okp4/ontology/vnext/schema/credential/digital-service/description/DigitalServiceDescriptionCredential> .
+<https://w3id.org/okp4/ontology/vnext/schema/credential/digital-service/description/72cab400-5bd6-4eb4-8605-a5ee8c1a45c9> <http://www.w3.org/1999/02/22-rdf-syntax-ns#type> <https://www.w3.org/2018/credentials#VerifiableCredential> .
+<https://w3id.org/okp4/ontology/vnext/schema/credential/digital-service/description/72cab400-5bd6-4eb4-8605-a5ee8c1a45c9> <https://www.w3.org/2018/credentials#credentialSubject> <did:key:zQ3shhb4SvzBRLbBonsvKb3WX6WoDeKWHpsXXXMhAJETqXAfB> .
+<https://w3id.org/okp4/ontology/vnext/schema/credential/digital-service/description/72cab400-5bd6-4eb4-8605-a5ee8c1a45c9> <https://www.w3.org/2018/credentials#issuanceDate> "2024-01-22T00:00:00"^^<http://www.w3.org/2001/XMLSchema#dateTime> .
+<https://w3id.org/okp4/ontology/vnext/schema/credential/digital-service/description/72cab400-5bd6-4eb4-8605-a5ee8c1a45c9> <https://www.w3.org/2018/credentials#expirationDate> "2025-01-22T00:00:00"^^<http://www.w3.org/2001/XMLSchema#dateTime> .
+<https://w3id.org/okp4/ontology/vnext/schema/credential/digital-service/description/72cab400-5bd6-4eb4-8605-a5ee8c1a45c9> <https://www.w3.org/2018/credentials#issuer> <did:key:zQ3shs7auhJSmVJpiUbQWco6bxxEhSqWnVEPvaBHBRvBKw6Q3> .
+<https://w3id.org/okp4/ontology/vnext/schema/credential/digital-service/description/72cab400-5bd6-4eb4-8605-a5ee8c1a45c9> <https://w3id.org/security#proof> _:b0 .
+_:b1 <http://purl.org/dc/terms/created> "2024-02-01T17:46:53.676947Z"^^<http://www.w3.org/2001/XMLSchema#dateTime> _:b0 .
+_:b1 <http://www.w3.org/1999/02/22-rdf-syntax-ns#type> <https://w3id.org/security#Ed25519Signature2020> _:b0 .
+_:b1 <https://w3id.org/security#proofPurpose> <https://w3id.org/security#assertionMethod> _:b0 .
+_:b1 <https://w3id.org/security#proofValue> "z3WboEDRwsWokH8vQrveVWbg6fQnqhHfhrkGHT9tyG2GYgzQVZ9zFW6eK2ZNcnGhydqXWDwwTsZq29e7cHJkbnVkF"^^<https://w3id.org/security#multibase> _:b0 .
+_:b1 <https://w3id.org/security#verificationMethod> <did:key:z6MkpwdnLPAm4apwcrRYQ6fZ3rAcqjLZR4AMk14vimfnozqY#z6MkpwdnLPAm4apwcrRYQ6fZ3rAcqjLZR4AMk14vimfnozqY> _:b0 .

--- a/contracts/okp4-dataverse/testdata/vc-unsupported-4.nq
+++ b/contracts/okp4-dataverse/testdata/vc-unsupported-4.nq
@@ -1,7 +1,6 @@
 <did:key:zQ3shhb4SvzBRLbBonsvKb3WX6WoDeKWHpsXXXMhAJETqXAfB> <https://w3id.org/okp4/ontology/vnext/schema/credential/digital-service/description/hasCategory> <https://w3id.org/okp4/ontology/vnext/thesaurus/digital-service-category/Storage> .
 <did:key:zQ3shhb4SvzBRLbBonsvKb3WX6WoDeKWHpsXXXMhAJETqXAfB> <https://w3id.org/okp4/ontology/vnext/schema/credential/digital-service/description/hasTag> "Cloud" .
-<did:key:zQ3shhb4SvzBRLbBonsvKb3WX6WoDeKWHpsXXXMhAJETqXAfB> <claim:hasSubElem> <claim:subElem> .
-<claim:subElem> <claim:isSubElem> "yes I am" .
+<did:key:zQ3shhb4SvzBRLbBonsvKb3WX6WoDeKWHpsXXXMhAJETqXAfB> <dataverse:credential#claim> "this shall not be allowed" .
 <https://w3id.org/okp4/ontology/vnext/schema/credential/digital-service/description/72cab400-5bd6-4eb4-8605-a5ee8c1a45c9> <http://www.w3.org/1999/02/22-rdf-syntax-ns#type> <https://w3id.org/okp4/ontology/vnext/schema/credential/digital-service/description/DigitalServiceDescriptionCredential> .
 <https://w3id.org/okp4/ontology/vnext/schema/credential/digital-service/description/72cab400-5bd6-4eb4-8605-a5ee8c1a45c9> <http://www.w3.org/1999/02/22-rdf-syntax-ns#type> <https://www.w3.org/2018/credentials#VerifiableCredential> .
 <https://w3id.org/okp4/ontology/vnext/schema/credential/digital-service/description/72cab400-5bd6-4eb4-8605-a5ee8c1a45c9> <https://www.w3.org/2018/credentials#credentialSubject> <did:key:zQ3shhb4SvzBRLbBonsvKb3WX6WoDeKWHpsXXXMhAJETqXAfB> .

--- a/packages/okp4-rdf/src/normalize.rs
+++ b/packages/okp4-rdf/src/normalize.rs
@@ -2,7 +2,7 @@ use itertools::Itertools;
 use rio_api::model::{BlankNode, GraphName, Quad, Subject, Term};
 use sha2;
 use sha2::Digest;
-use std::collections::hash_map::Entry;
+use std::collections::hash_map::{Entry, Iter};
 use std::collections::{BTreeMap, HashMap};
 use thiserror::Error;
 
@@ -376,6 +376,10 @@ impl IdentifierIssuer {
 
     pub fn issued(&self, identifier: &str) -> bool {
         self.issued.contains_key(identifier)
+    }
+
+    pub fn issued_iter(&self) -> Iter<'_, String, (u128, String)> {
+        self.issued.iter()
     }
 }
 


### PR DESCRIPTION
This PR brings the support to VC containing a claim with a hierarchy based on named nodes.

## Context

When a claim express a hierarchy through named nodes it poses the problem of the credential isolation once stored in the cognitarium. We want to have as named node subject only the credential identifier, any hierarchy descending from the credential shall be based on blank nodes to ensure consistency at revocation and security by avoiding extending other credential properties.

To this point claim containing named nodes hierarchies were rejected, a special treatment to support them is proposed hereafter.

## Proposed solution

The idea is to replace the named node making the hierarchical link by a blank node, and then to add a triple linking the original named node to the replacing blank node using the dedicated predicate `<dataverse:claim#original-node>`, for example:

Taking the following credential RDF in input:
```nq
<https://w3id.org/okp4/ontology/vnext/schema/credential/digital-service/description/72cab400-5bd6-4eb4-8605-a5ee8c1a45c9> <https://www.w3.org/2018/credentials#credentialSubject> <did:key:zQ3shhb4SvzBRLbBonsvKb3WX6WoDeKWHpsXXXMhAJETqXAfB> .
<did:key:zQ3shhb4SvzBRLbBonsvKb3WX6WoDeKWHpsXXXMhAJETqXAfB> <https://w3id.org/okp4/ontology/vnext/schema/credential/digital-service/description/hasCategory> <https://w3id.org/okp4/ontology/vnext/thesaurus/digital-service-category/Storage> .
<did:key:zQ3shhb4SvzBRLbBonsvKb3WX6WoDeKWHpsXXXMhAJETqXAfB> <test:claim#named-hierarchy> <test:named-link> .
<test:named-link> <test:claim#nested-predicate> "nested value" .
```

Will be serialised and stored in the cognitarium this way:
```nq
<https://w3id.org/okp4/ontology/vnext/schema/credential/digital-service/description/72cab400-5bd6-4eb4-8605-a5ee8c1a45c9> <dataverse:credential#subject> <did:key:zQ3shhb4SvzBRLbBonsvKb3WX6WoDeKWHpsXXXMhAJETqXAfB> .
<https://w3id.org/okp4/ontology/vnext/schema/credential/digital-service/description/72cab400-5bd6-4eb4-8605-a5ee8c1a45c9> <dataverse:credential#claim> _:c0 .
_:c0 <https://w3id.org/okp4/ontology/vnext/schema/credential/digital-service/description/hasCategory> <https://w3id.org/okp4/ontology/vnext/thesaurus/digital-service-category/Storage> .
_:c0 <test:claim#named-hierarchy> _:a0 .
_:a0 <test:claim#nested-predicate> \"nested value\" .
_:a0 <dataverse:claim#original-node> <test:named-link> .
```

## Security

This PR also brings a security fix ensuring that dataverse reserved predicates are refused as inputs.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
	- Introduced enhanced serialization for Dataverse credentials, ensuring better handling of reserved predicates.
	- Added support for named and blank issuers in credential triples.
- **Refactor**
	- Updated method calls for credential serialization to improve code efficiency.
- **Tests**
	- Implemented new tests to validate serialization and reserved predicates handling.
- **Documentation**
	- Added new RDF triples for digital service credentials, showcasing the structure and expected attributes.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->