### PR TITLE
Refactor/errors

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -812,6 +812,7 @@ dependencies = [
  "okp4-logic-bindings",
  "okp4-objectarium",
  "okp4-objectarium-client",
+ "okp4-wasm",
  "schemars",
  "serde",
  "thiserror",
@@ -824,6 +825,7 @@ version = "4.1.0"
 dependencies = [
  "cosmwasm-std",
  "form_urlencoded",
+ "okp4-wasm",
  "schemars",
  "serde",
  "serde-json-wasm 1.0.1",
@@ -861,8 +863,8 @@ name = "okp4-objectarium-client"
 version = "4.1.0"
 dependencies = [
  "cosmwasm-std",
- "okp4-logic-bindings",
  "okp4-objectarium",
+ "okp4-wasm",
  "schemars",
  "serde",
 ]
@@ -879,6 +881,19 @@ dependencies = [
  "rio_xml",
  "sha2 0.10.8",
  "thiserror",
+]
+
+[[package]]
+name = "okp4-wasm"
+version = "4.1.0"
+dependencies = [
+ "cosmwasm-std",
+ "form_urlencoded",
+ "schemars",
+ "serde",
+ "serde-json-wasm 1.0.1",
+ "thiserror",
+ "url",
 ]
 
 [[package]]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -21,6 +21,7 @@ okp4-objectarium = { path = "contracts/okp4-objectarium", features = [
 ] }
 okp4-objectarium-client = { path = "packages/okp4-objectarium-client" }
 okp4-rdf = { path = "packages/okp4-rdf" }
+okp4-wasm = { path = "packages/okp4-wasm" }
 rdf-types = "0.18.2"
 rio_api = "0.8.4"
 rio_turtle = "0.8.4"

--- a/contracts/okp4-law-stone/Cargo.toml
+++ b/contracts/okp4-law-stone/Cargo.toml
@@ -38,6 +38,7 @@ itertools = "0.12.1"
 okp4-logic-bindings.workspace = true
 okp4-objectarium-client.workspace = true
 okp4-objectarium.workspace = true
+okp4-wasm.workspace = true
 schemars.workspace = true
 serde.workspace = true
 thiserror.workspace = true

--- a/contracts/okp4-law-stone/src/contract.rs
+++ b/contracts/okp4-law-stone/src/contract.rs
@@ -270,11 +270,11 @@ mod tests {
         SubMsgResponse, SubMsgResult, SystemError, SystemResult, WasmQuery,
     };
     use okp4_logic_bindings::testing::mock::mock_dependencies_with_logic_handler;
-    use okp4_logic_bindings::uri::CosmwasmUri;
     use okp4_logic_bindings::{
         Answer, AskResponse, LogicCustomQuery, Result as LogicResult, Substitution,
     };
     use okp4_objectarium::msg::PageInfo;
+    use okp4_wasm::uri::CosmwasmUri;
     use std::collections::VecDeque;
 
     fn custom_logic_handler_with_dependencies(

--- a/contracts/okp4-law-stone/src/contract.rs
+++ b/contracts/okp4-law-stone/src/contract.rs
@@ -77,7 +77,7 @@ pub mod execute {
             .query_wasm_contract_info(env.contract.address)?
             .admin
         {
-            Some(admin_addr) if admin_addr != info.sender => Err(ContractError::Unauthorized {}),
+            Some(admin_addr) if admin_addr != info.sender => Err(ContractError::Unauthorized),
             _ => Ok(()),
         }?;
 
@@ -906,18 +906,8 @@ mod tests {
     #[test]
     fn break_stone_admin() {
         let cases = vec![
-            (
-                "not-admin",
-                true,
-                false,
-                Some(ContractError::Unauthorized {}),
-            ),
-            (
-                "not-admin",
-                true,
-                true,
-                Some(ContractError::Unauthorized {}),
-            ),
+            ("not-admin", true, false, Some(ContractError::Unauthorized)),
+            ("not-admin", true, true, Some(ContractError::Unauthorized)),
             ("admin", true, false, None),
             ("anyone", false, false, None),
         ];

--- a/contracts/okp4-law-stone/src/contract.rs
+++ b/contracts/okp4-law-stone/src/contract.rs
@@ -163,11 +163,11 @@ pub mod query {
     }
 
     pub fn build_ask_query(program: ObjectRef, query: String) -> StdResult<LogicCustomQuery> {
-        let program_uri = object_ref_to_uri(program)?.to_string();
+        let program_uri = object_ref_to_uri(program)?;
 
         Ok(LogicCustomQuery::Ask {
-            program: String::new(),
-            query: ["consult('", program_uri.as_str(), "'), ", query.as_str()].join(""),
+            program: format!(":- consult('{}').", program_uri),
+            query,
         })
     }
 }

--- a/contracts/okp4-law-stone/src/error.rs
+++ b/contracts/okp4-law-stone/src/error.rs
@@ -21,7 +21,7 @@ pub enum ContractError {
     LogicAskResponse(LogicAskResponseError),
 
     #[error("Only the contract admin can perform this operation.")]
-    Unauthorized {},
+    Unauthorized,
 }
 
 #[derive(Error, Debug, PartialEq, Eq)]

--- a/contracts/okp4-law-stone/src/error.rs
+++ b/contracts/okp4-law-stone/src/error.rs
@@ -10,10 +10,10 @@ pub enum ContractError {
     Std(#[from] StdError),
 
     #[error("{0}")]
-    Parse(#[from] ParseReplyError),
+    ParseReplyError(#[from] ParseReplyError),
 
-    #[error("Invalid reply message: {0}")]
-    InvalidReplyMsg(StdError),
+    #[error("An unknown reply ID was received.")]
+    UnknownReplyID,
 
     #[error("Cannot parse cosmwasm uri: {0}")]
     ParseCosmwasmUri(CosmwasmUriError),

--- a/contracts/okp4-law-stone/src/error.rs
+++ b/contracts/okp4-law-stone/src/error.rs
@@ -1,6 +1,7 @@
 use cosmwasm_std::StdError;
 use cw_utils::ParseReplyError;
-use okp4_logic_bindings::error::{CosmwasmUriError, TermParseError};
+use okp4_logic_bindings::error::TermParseError;
+use okp4_wasm::error::CosmwasmUriError;
 use thiserror::Error;
 
 #[derive(Error, Debug, PartialEq)]

--- a/contracts/okp4-law-stone/src/helper.rs
+++ b/contracts/okp4-law-stone/src/helper.rs
@@ -2,10 +2,10 @@ use crate::error::LogicAskResponseError;
 use crate::ContractError;
 use cosmwasm_std::{Event, StdError, StdResult};
 use itertools::Itertools;
-use okp4_logic_bindings::error::CosmwasmUriError;
-use okp4_logic_bindings::uri::CosmwasmUri;
 use okp4_logic_bindings::{AskResponse, TermValue};
 use okp4_objectarium_client::ObjectRef;
+use okp4_wasm::error::CosmwasmUriError;
+use okp4_wasm::uri::CosmwasmUri;
 use std::any::type_name;
 
 pub fn object_ref_to_uri(object: ObjectRef) -> StdResult<CosmwasmUri> {

--- a/contracts/okp4-law-stone/src/helper.rs
+++ b/contracts/okp4-law-stone/src/helper.rs
@@ -14,13 +14,12 @@ pub fn object_ref_to_uri(object: ObjectRef) -> StdResult<CosmwasmUri> {
     })
 }
 
-pub fn get_reply_event_attribute(events: Vec<Event>, key: String) -> Option<String> {
-    return events
+pub fn get_reply_event_attribute(events: &[Event], key: &str) -> Option<String> {
+    events
         .iter()
-        .flat_map(|e| e.attributes.clone())
-        .filter(|a| a.key == key)
-        .map(|a| a.value)
-        .next();
+        .flat_map(|e| e.attributes.iter())
+        .find(|a| a.key == key)
+        .map(|a| a.value.clone())
 }
 
 fn term_as_vec(term: TermValue) -> Result<Vec<String>, ContractError> {

--- a/contracts/okp4-law-stone/src/msg.rs
+++ b/contracts/okp4-law-stone/src/msg.rs
@@ -30,17 +30,27 @@ pub enum ExecuteMsg {
 #[derive(QueryResponses)]
 pub enum QueryMsg {
     /// # Ask
-    /// If not broken, ask the logic module the provided query with the law program loaded.
+    /// Submits a Prolog query string to the `Logic` module, evaluating it against the
+    /// law program associated with this contract.
+    ///
+    /// If the law stone is broken the query returns a response with the error `error(system_error(broken_law_stone),root)`
+    /// set in the `answer` field.
     #[returns(AskResponse)]
     Ask { query: String },
 
     /// # Program
-    /// If not broken, returns the law program location information.
+    /// Retrieves the location metadata of the law program bound to this contract.
+    ///
+    /// This includes the contract address of the `objectarium` and the program object ID,
+    /// where the law program's code can be accessed.
     #[returns(ProgramResponse)]
     Program,
 
     /// # ProgramCode
-    /// ProgramCode returns the law program code.
+    /// Fetches the raw code of the law program tied to this contract.
+    ///
+    /// If the law stone is broken, the query may fail if the program is no longer available in the
+    /// `Objectarium`.
     #[returns(Binary)]
     ProgramCode,
 }

--- a/contracts/okp4-objectarium/src/contract.rs
+++ b/contracts/okp4-objectarium/src/contract.rs
@@ -161,7 +161,7 @@ pub mod execute {
 
         Ok(Response::new()
             .add_attribute("action", "store_object")
-            .add_attribute("id", object.id.clone()))
+            .add_attribute("id", object.id.to_string()))
     }
 
     pub fn pin_object(
@@ -1260,7 +1260,7 @@ mod tests {
             .save(deps.as_mut().storage, &data)
             .expect("no error when storing data");
 
-        let msg = QueryMsg::ObjectData { id: id.into() };
+        let msg = QueryMsg::ObjectData { id: id.to_string() };
 
         let result = query(deps.as_ref(), mock_env(), msg);
         assert_eq!(

--- a/contracts/okp4-objectarium/src/contract.rs
+++ b/contracts/okp4-objectarium/src/contract.rs
@@ -419,6 +419,8 @@ impl From<state::HashAlgorithm> for crypto::HashAlgorithm {
 #[cfg(test)]
 mod tests {
     use super::*;
+    use crate::compress;
+    use crate::crypto::Hash;
     use crate::error::BucketError;
     use crate::msg::{
         BucketConfig, BucketLimitsBuilder, BucketResponse, CompressionAlgorithm, HashAlgorithm,
@@ -427,7 +429,7 @@ mod tests {
     use base64::{engine::general_purpose, Engine as _};
     use cosmwasm_std::testing::{mock_dependencies, mock_env, mock_info};
     use cosmwasm_std::StdError::NotFound;
-    use cosmwasm_std::{from_json, Attribute, Order, StdError, Uint128};
+    use cosmwasm_std::{from_json, Addr, Attribute, Order, StdError, Uint128};
     use std::any::type_name;
 
     fn decode_hex(hex: &str) -> Vec<u8> {
@@ -1233,6 +1235,41 @@ mod tests {
             let result = query(deps.as_ref(), mock_env(), msg).unwrap();
             assert_eq!(result, to_json_binary(&data).unwrap());
         }
+    }
+
+    #[test]
+    fn object_data_error() {
+        let mut deps = mock_dependencies();
+        let id: Hash = vec![1, 2, 3].into();
+        let data = &vec![255, 255, 0];
+
+        let object = &Object {
+            id: id.clone(),
+            owner: Addr::unchecked("john"),
+            size: 42u8.into(),
+            pin_count: Uint128::one(),
+            compression: compress::CompressionAlgorithm::Lzma,
+            compressed_size: Uint128::from(data.len() as u128),
+        };
+
+        objects()
+            .save(deps.as_mut().storage, object.id.clone(), object)
+            .expect("no error when storing object");
+        let data_path = DATA.key(id.clone());
+        data_path
+            .save(deps.as_mut().storage, &data)
+            .expect("no error when storing data");
+
+        let msg = QueryMsg::ObjectData { id: id.into() };
+
+        let result = query(deps.as_ref(), mock_env(), msg);
+        assert_eq!(
+            result,
+            Err(StdError::serialize_err(
+                "Lzma",
+                "lzma error: LZMA header invalid properties: 255 must be < 225"
+            ))
+        );
     }
 
     #[test]

--- a/contracts/okp4-objectarium/src/crypto.rs
+++ b/contracts/okp4-objectarium/src/crypto.rs
@@ -6,6 +6,7 @@ use serde::{Deserialize, Serialize};
 use sha2;
 use sha2::Digest;
 use std::any::type_name;
+use std::fmt;
 
 /// HashAlgorithm is the type of the hash algorithm.
 pub enum HashAlgorithm {
@@ -34,7 +35,7 @@ impl HashAlgorithm {
     }
 }
 
-/// Hash represent a Object hash as binary value.  
+/// Hash represent a Object hash as binary value.
 #[derive(
     Serialize, Deserialize, Clone, Debug, PartialEq, Eq, PartialOrd, Ord, Hash, JsonSchema,
 )]
@@ -83,9 +84,11 @@ impl TryFrom<String> for Hash {
     }
 }
 
-impl From<Hash> for String {
-    fn from(hash: Hash) -> Self {
-        base16ct::lower::encode_string(hash.0.as_slice())
+// Allows for a (user-friendly) string representation of Hash as a lower Base16 (hex) encoding.
+impl fmt::Display for Hash {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        let hex_string = base16ct::lower::encode_string(&self.0);
+        write!(f, "{}", hex_string)
     }
 }
 

--- a/contracts/okp4-objectarium/src/state.rs
+++ b/contracts/okp4-objectarium/src/state.rs
@@ -275,7 +275,7 @@ pub struct Object {
 impl From<&Object> for ObjectResponse {
     fn from(object: &Object) -> Self {
         ObjectResponse {
-            id: object.id.clone().into(),
+            id: object.id.to_string(),
             size: object.size,
             owner: object.owner.clone().into(),
             is_pinned: object.pin_count > Uint128::zero(),

--- a/docs/okp4-cognitarium.md
+++ b/docs/okp4-cognitarium.md
@@ -876,4 +876,4 @@ Represents a condition in a [WhereClause].
 
 ---
 
-_Rendered by [Fadroma](https://fadroma.tech) ([@fadroma/schema 1.1.0](https://www.npmjs.com/package/@fadroma/schema)) from `okp4-cognitarium.json` (`a04a40216c76a302`)_
+_Rendered by [Fadroma](https://fadroma.tech) ([@fadroma/schema 1.1.0](https://www.npmjs.com/package/@fadroma/schema)) from `okp4-cognitarium.json` (`6f72bb04e2230e19`)_

--- a/docs/okp4-dataverse.md
+++ b/docs/okp4-dataverse.md
@@ -238,5 +238,5 @@ let b = Uint64::from(70u32); assert_eq!(b.u64(), 70); ```
 
 ---
 
-*Rendered by [Fadroma](https://fadroma.tech) ([@fadroma/schema 1.1.0](https://www.npmjs.com/package/@fadroma/schema)) from `okp4-dataverse.json` (`6c4e48ca82d04a6a`)*
+*Rendered by [Fadroma](https://fadroma.tech) ([@fadroma/schema 1.1.0](https://www.npmjs.com/package/@fadroma/schema)) from `okp4-dataverse.json` (`b906ba32d6e0720c`)*
 ````

--- a/docs/okp4-law-stone.md
+++ b/docs/okp4-law-stone.md
@@ -41,7 +41,9 @@ Query messages
 
 ### QueryMsg::Ask
 
-If not broken, ask the logic module the provided query with the law program loaded.
+Submits a Prolog query string to the `Logic` module, evaluating it against the law program associated with this contract.
+
+If the law stone is broken the query returns a response with the error `error(system_error(broken_law_stone),root)` set in the `answer` field.
 
 | parameter   | description                |
 | ----------- | -------------------------- |
@@ -50,7 +52,9 @@ If not broken, ask the logic module the provided query with the law program load
 
 ### QueryMsg::Program
 
-If not broken, returns the law program location information.
+Retrieves the location metadata of the law program bound to this contract.
+
+This includes the contract address of the `objectarium` and the program object ID, where the law program's code can be accessed.
 
 | literal     |
 | ----------- |
@@ -58,7 +62,9 @@ If not broken, returns the law program location information.
 
 ### QueryMsg::ProgramCode
 
-ProgramCode returns the law program code.
+Fetches the raw code of the law program tied to this contract.
+
+If the law stone is broken, the query may fail if the program is no longer available in the `Objectarium`.
 
 | literal          |
 | ---------------- |
@@ -128,4 +134,4 @@ A string containing Base64-encoded data.
 
 ---
 
-_Rendered by [Fadroma](https://fadroma.tech) ([@fadroma/schema 1.1.0](https://www.npmjs.com/package/@fadroma/schema)) from `okp4-law-stone.json` (`a95a2760652729c5`)_
+_Rendered by [Fadroma](https://fadroma.tech) ([@fadroma/schema 1.1.0](https://www.npmjs.com/package/@fadroma/schema)) from `okp4-law-stone.json` (`f92ef76322c09083`)_

--- a/docs/okp4-objectarium.md
+++ b/docs/okp4-objectarium.md
@@ -511,4 +511,4 @@ A string containing a 128-bit integer in decimal representation.
 
 ---
 
-_Rendered by [Fadroma](https://fadroma.tech) ([@fadroma/schema 1.1.0](https://www.npmjs.com/package/@fadroma/schema)) from `okp4-objectarium.json` (`483acdc660c72c5f`)_
+_Rendered by [Fadroma](https://fadroma.tech) ([@fadroma/schema 1.1.0](https://www.npmjs.com/package/@fadroma/schema)) from `okp4-objectarium.json` (`b4d8508c7abc145b`)_

--- a/packages/okp4-logic-bindings/Cargo.toml
+++ b/packages/okp4-logic-bindings/Cargo.toml
@@ -7,6 +7,7 @@ version = "4.1.0"
 [dependencies]
 cosmwasm-std.workspace = true
 form_urlencoded = "1.2.1"
+okp4-wasm.workspace = true
 schemars.workspace = true
 serde-json-wasm.workspace = true
 serde.workspace = true

--- a/packages/okp4-logic-bindings/src/error.rs
+++ b/packages/okp4-logic-bindings/src/error.rs
@@ -1,21 +1,5 @@
 use std::string::FromUtf8Error;
 use thiserror::Error;
-use url::ParseError;
-
-#[derive(Error, Debug, PartialEq, Eq)]
-pub enum CosmwasmUriError {
-    #[error("{0}")]
-    ParseURI(#[from] ParseError),
-
-    #[error("{0}")]
-    ParseQuery(String),
-
-    #[error("{0}")]
-    SerializeQuery(String),
-
-    #[error("Malformed URI: {0}")]
-    Malformed(String),
-}
 
 #[derive(Error, Debug, PartialEq, Eq)]
 pub enum TermParseError {

--- a/packages/okp4-logic-bindings/src/lib.rs
+++ b/packages/okp4-logic-bindings/src/lib.rs
@@ -1,7 +1,6 @@
 pub mod error;
 mod query;
 mod term_parser;
-pub mod uri;
 
 pub use query::{Answer, AskResponse, LogicCustomQuery, Result, Substitution};
 pub use term_parser::TermValue;

--- a/packages/okp4-logic-bindings/src/query.rs
+++ b/packages/okp4-logic-bindings/src/query.rs
@@ -29,6 +29,20 @@ pub struct Answer {
     pub results: Vec<Result>,
 }
 
+impl Answer {
+    /// Create a new Answer with an error message.
+    pub fn from_error(error: String) -> Self {
+        Self {
+            has_more: false,
+            variables: vec![],
+            results: vec![Result {
+                error: Some(error),
+                substitutions: vec![],
+            }],
+        }
+    }
+}
+
 #[derive(Serialize, Deserialize, Default, Clone, PartialEq, Eq, JsonSchema, Debug)]
 #[serde(rename_all = "snake_case")]
 pub struct Result {

--- a/packages/okp4-logic-bindings/src/uri.rs
+++ b/packages/okp4-logic-bindings/src/uri.rs
@@ -1,6 +1,7 @@
 use crate::error::CosmwasmUriError;
 use serde::{de, ser};
 use std::collections::HashMap;
+use std::fmt::Display;
 use url::Url;
 
 const COSMWASM_SCHEME: &str = "cosmwasm";
@@ -96,10 +97,10 @@ impl TryFrom<String> for CosmwasmUri {
     }
 }
 
-impl ToString for CosmwasmUri {
-    fn to_string(&self) -> String {
+impl Display for CosmwasmUri {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
         let encoded_query = self.clone().encode_query();
-        match self.contract_name.clone() {
+        let str = match self.contract_name.clone() {
             Some(name) => [
                 COSMWASM_SCHEME,
                 ":",
@@ -118,7 +119,8 @@ impl ToString for CosmwasmUri {
                 encoded_query.as_str(),
             ]
             .join(""),
-        }
+        };
+        write!(f, "{}", str)
     }
 }
 

--- a/packages/okp4-objectarium-client/src/object.rs
+++ b/packages/okp4-objectarium-client/src/object.rs
@@ -1,8 +1,8 @@
 use cosmwasm_std::{to_json_binary, Coin, StdResult, WasmMsg};
-use okp4_logic_bindings::error::CosmwasmUriError;
-use okp4_logic_bindings::uri::CosmwasmUri;
 use okp4_objectarium::msg::QueryMsg::ObjectData;
 use okp4_objectarium::msg::{ExecuteMsg, QueryMsg};
+use okp4_wasm::error::CosmwasmUriError;
+use okp4_wasm::uri::CosmwasmUri;
 use serde::{Deserialize, Serialize};
 
 const CONTRACT_NAME: &str = "okp4-objectarium";

--- a/packages/okp4-wasm/Cargo.toml
+++ b/packages/okp4-wasm/Cargo.toml
@@ -1,12 +1,14 @@
 [package]
 authors = ["OKP4"]
 edition = "2021"
-name = "okp4-objectarium-client"
+name = "okp4-wasm"
 version = "4.1.0"
 
 [dependencies]
 cosmwasm-std.workspace = true
-okp4-objectarium.workspace = true
-okp4-wasm.workspace = true
+form_urlencoded = "1.2.1"
 schemars.workspace = true
+serde-json-wasm.workspace = true
 serde.workspace = true
+thiserror.workspace = true
+url = "2.5.0"

--- a/packages/okp4-wasm/Makefile.toml
+++ b/packages/okp4-wasm/Makefile.toml
@@ -1,0 +1,1 @@
+[tasks.schema]

--- a/packages/okp4-wasm/README.md
+++ b/packages/okp4-wasm/README.md
@@ -1,0 +1,3 @@
+# RDF
+
+Package that holds useful components to manage with `RDF` data, typically reading / writing.

--- a/packages/okp4-wasm/src/error.rs
+++ b/packages/okp4-wasm/src/error.rs
@@ -1,0 +1,17 @@
+use thiserror::Error;
+use url::ParseError;
+
+#[derive(Error, Debug, PartialEq, Eq)]
+pub enum CosmwasmUriError {
+    #[error("{0}")]
+    ParseURI(#[from] ParseError),
+
+    #[error("{0}")]
+    ParseQuery(String),
+
+    #[error("{0}")]
+    SerializeQuery(String),
+
+    #[error("Malformed URI: {0}")]
+    Malformed(String),
+}

--- a/packages/okp4-wasm/src/lib.rs
+++ b/packages/okp4-wasm/src/lib.rs
@@ -1,0 +1,2 @@
+pub mod error;
+pub mod uri;

--- a/packages/okp4-wasm/src/uri.rs
+++ b/packages/okp4-wasm/src/uri.rs
@@ -7,8 +7,12 @@ use url::Url;
 const COSMWASM_SCHEME: &str = "cosmwasm";
 const COSMWASM_QUERY_PARAM: &str = "query";
 
-/// Represents a file system URI used to load files from the logic module dedicated to the resolution
-/// of data coming from a CosmWasm smart contract query. The URI having the form:
+/// A CosmWasm URI identifies a resource on a blockchain by referencing a specific instantiated
+/// smart contract. It includes the contract's address and uses query parameters to encode the message
+/// intended for the contract. The resource identified by the URI is the response provided by the
+/// smart contract following this query.
+///
+/// Its general form is as follows:
 ///
 /// `cosmwasm:{contract_name}:{contract_address}?query={contract_query}`
 ///


### PR DESCRIPTION
This PR adds some improvements aimed at enhancing code maintainability and consistency for error management:

- Wasm-related functionalities have been moved into a dedicated crate (to improve modularity).
- Standardization of the syntax of enum variants to omit braces where they are not needed (as far as i see this is not common in cosmwasm project, but aligns with Rust's idiomatic practices, I guess).
- Unification of error handling for queries. Using `StdResult<T>` for query responses, moving away from custom error formats. 
- ⚠️ breaking change: Regarding the handling of broken law stones, we're shifting towards returning a Prolog error message rather than a generic smart contract error: `error(system_error(broken_law_stone),root)`

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
	- Enhanced error handling across various contracts and modules for improved user feedback.
	- Updated and improved descriptions in user-facing messages for clearer communication.
	- Introduced new test cases for better reliability and performance.
- **Bug Fixes**
	- Fixed unauthorized error handling in `execute` module to prevent unauthorized access.
	- Updated handling of `id` field in `Object` struct for consistency.
- **Documentation**
	- Updated documentation in multiple areas to reflect changes in error handling and description enhancements.
	- Introduced `RDF` package documentation for managing RDF data.
- **Refactor**
	- Simplified error handling logic in `okp4-logic-bindings`.
	- Replaced certain dependencies with `okp4-wasm` for streamlined integration and maintenance.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->