### PR TITLE
Chore/secure docs gen

### DIFF
--- a/Makefile.toml
+++ b/Makefile.toml
@@ -129,6 +129,12 @@ echo "🧹 Cleaning old documentation..."
 rm -rf $SCHEMA_FOLDER
 rm -rf $DOCS_FOLDER
 
+if [[ $(jq --version) != jq-1\.7* ]]
+then
+	echo "Error: jq version 1.7 is needed"
+  exit 1
+fi
+
 echo "📚 Generating documentation in ${DOCS_FOLDER} folder..."
 
 mkdir -p $SCHEMA_FOLDER

--- a/Makefile.toml
+++ b/Makefile.toml
@@ -119,6 +119,14 @@ then
    exit 1
 fi
 echo "✅ \`perl\` installed"
+
+echo "❔ Checking \`jq\` installation..."
+if [[ $(jq --version) != jq-1\.7* ]]
+then
+  echo "\n❌ Require jq version 1.7"
+  exit 1
+fi
+echo "✅ \`jq\` installed"
 '''
 
 [tasks.docs-generate]
@@ -128,12 +136,6 @@ script = '''
 echo "🧹 Cleaning old documentation..."
 rm -rf $SCHEMA_FOLDER
 rm -rf $DOCS_FOLDER
-
-if [[ $(jq --version) != jq-1\.7* ]]
-then
-	echo "Error: jq version 1.7 is needed"
-  exit 1
-fi
 
 echo "📚 Generating documentation in ${DOCS_FOLDER} folder..."
 

--- a/docs/okp4-cognitarium.md
+++ b/docs/okp4-cognitarium.md
@@ -876,4 +876,4 @@ Represents a condition in a [WhereClause].
 
 ---
 
-_Rendered by [Fadroma](https://fadroma.tech) ([@fadroma/schema 1.1.0](https://www.npmjs.com/package/@fadroma/schema)) from `okp4-cognitarium.json` (`6f72bb04e2230e19`)_
+_Rendered by [Fadroma](https://fadroma.tech) ([@fadroma/schema 1.1.0](https://www.npmjs.com/package/@fadroma/schema)) from `okp4-cognitarium.json` (`a04a40216c76a302`)_

--- a/docs/okp4-dataverse.md
+++ b/docs/okp4-dataverse.md
@@ -238,5 +238,5 @@ let b = Uint64::from(70u32); assert_eq!(b.u64(), 70); ```
 
 ---
 
-*Rendered by [Fadroma](https://fadroma.tech) ([@fadroma/schema 1.1.0](https://www.npmjs.com/package/@fadroma/schema)) from `okp4-dataverse.json` (`b906ba32d6e0720c`)*
+*Rendered by [Fadroma](https://fadroma.tech) ([@fadroma/schema 1.1.0](https://www.npmjs.com/package/@fadroma/schema)) from `okp4-dataverse.json` (`6c4e48ca82d04a6a`)*
 ````

--- a/docs/okp4-law-stone.md
+++ b/docs/okp4-law-stone.md
@@ -134,4 +134,4 @@ A string containing Base64-encoded data.
 
 ---
 
-_Rendered by [Fadroma](https://fadroma.tech) ([@fadroma/schema 1.1.0](https://www.npmjs.com/package/@fadroma/schema)) from `okp4-law-stone.json` (`f92ef76322c09083`)_
+_Rendered by [Fadroma](https://fadroma.tech) ([@fadroma/schema 1.1.0](https://www.npmjs.com/package/@fadroma/schema)) from `okp4-law-stone.json` (`1c8e531eb7eea016`)_

--- a/docs/okp4-objectarium.md
+++ b/docs/okp4-objectarium.md
@@ -511,4 +511,4 @@ A string containing a 128-bit integer in decimal representation.
 
 ---
 
-_Rendered by [Fadroma](https://fadroma.tech) ([@fadroma/schema 1.1.0](https://www.npmjs.com/package/@fadroma/schema)) from `okp4-objectarium.json` (`b4d8508c7abc145b`)_
+_Rendered by [Fadroma](https://fadroma.tech) ([@fadroma/schema 1.1.0](https://www.npmjs.com/package/@fadroma/schema)) from `okp4-objectarium.json` (`483acdc660c72c5f`)_


### PR DESCRIPTION
Ensure deterministic docs generation by enforcing jq version `1.7`.

Also re-generate docs to make linters happy.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit


- **Chores**
	- Added a version check for `jq` in the build process.

- **Documentation**
	- Updated hash values in the rendered documentation for:
		- `okp4-cognitarium`
		- `okp4-dataverse`
		- `okp4-law-stone`
		- `okp4-objectarium`

<!-- end of auto-generated comment: release notes by coderabbit.ai -->