### PR TITLE
build(project): get rid of warning messages from Cargo

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,5 +1,17 @@
 [workspace]
 members = ["contracts/*", "packages/*"]
+resolver = "2"
+
+[profile.release]
+codegen-units = 1
+debug = false
+debug-assertions = false
+incremental = false
+lto = true
+opt-level = 3
+overflow-checks = true
+panic = 'abort'
+rpath = false
 
 [workspace.dependencies]
 cosmwasm-schema = "1.5.3"

--- a/contracts/okp4-cognitarium/Cargo.toml
+++ b/contracts/okp4-cognitarium/Cargo.toml
@@ -16,17 +16,6 @@ exclude = [
 [lib]
 crate-type = ["cdylib", "rlib"]
 
-[profile.release]
-codegen-units = 1
-debug = false
-debug-assertions = false
-incremental = false
-lto = true
-opt-level = 3
-overflow-checks = true
-panic = 'abort'
-rpath = false
-
 [dependencies]
 blake3 = "1.5.1"
 cosmwasm-schema.workspace = true

--- a/contracts/okp4-dataverse/Cargo.toml
+++ b/contracts/okp4-dataverse/Cargo.toml
@@ -16,17 +16,6 @@ exclude = [
 [lib]
 crate-type = ["cdylib", "rlib"]
 
-[profile.release]
-codegen-units = 1
-debug = false
-debug-assertions = false
-incremental = false
-lto = true
-opt-level = 3
-overflow-checks = true
-panic = 'abort'
-rpath = false
-
 [dependencies]
 base64 = "0.22.0"
 bs58 = "0.5.1"

--- a/contracts/okp4-law-stone/Cargo.toml
+++ b/contracts/okp4-law-stone/Cargo.toml
@@ -16,17 +16,6 @@ exclude = [
 [lib]
 crate-type = ["cdylib", "rlib"]
 
-[profile.release]
-codegen-units = 1
-debug = false
-debug-assertions = false
-incremental = false
-lto = true
-opt-level = 3
-overflow-checks = true
-panic = 'abort'
-rpath = false
-
 [dependencies]
 cosmwasm-schema.workspace = true
 cosmwasm-std.workspace = true

--- a/contracts/okp4-objectarium/Cargo.toml
+++ b/contracts/okp4-objectarium/Cargo.toml
@@ -16,17 +16,6 @@ exclude = [
 [lib]
 crate-type = ["cdylib", "rlib"]
 
-[profile.release]
-codegen-units = 1
-debug = false
-debug-assertions = false
-incremental = false
-lto = true
-opt-level = 3
-overflow-checks = true
-panic = 'abort'
-rpath = false
-
 [dependencies]
 base16ct = { version = "0.2.0", features = ["alloc"] }
 bs58 = "0.5.1"


### PR DESCRIPTION
This PR fixes the warnings emitted by Cargo during build:

1.
```
warning: profiles for the non root package will be ignored, specify profiles at the workspace root:
```

2.
```
warning: virtual workspace defaulting to `resolver = "1"` despite one or more workspace members being on edition 2021 which implies `resolver = "2"`
note: to keep the current resolver, specify `workspace.resolver = "1"` in the workspace root's manifest
note: to use the edition 2021 resolver, specify `workspace.resolver = "2"` in the workspace root's manifest
```

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Chores**
	- Updated project configuration for improved performance and stability.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->