### PR TITLE
Feat/objectarium store already exist

### DIFF
--- a/contracts/okp4-objectarium/src/error.rs
+++ b/contracts/okp4-objectarium/src/error.rs
@@ -35,9 +35,6 @@ pub enum BucketError {
     #[error("Maximum object pins number exceeded: {0} / {1}")]
     MaxObjectPinsLimitExceeded(Uint128, Uint128),
 
-    #[error("Object is already stored")]
-    ObjectAlreadyStored,
-
     #[error("Compression algorithm is not accepted: {0:?} (accepted: \"{1:?}\")")]
     CompressionAlgorithmNotAccepted(CompressionAlgorithm, Vec<CompressionAlgorithm>),
 }
@@ -81,10 +78,6 @@ fn test_bucket_error_messages() {
         (
             ContractError::Bucket(BucketError::MaxObjectPinsLimitExceeded(5u8.into(), 2u8.into())),
             "Maximum object pins number exceeded: 5 / 2",
-        ),
-        (
-            ContractError::Bucket(BucketError::ObjectAlreadyStored),
-            "Object is already stored",
         ),
         (
             ContractError::Bucket(BucketError::CompressionAlgorithmNotAccepted(

--- a/contracts/okp4-objectarium/src/msg.rs
+++ b/contracts/okp4-objectarium/src/msg.rs
@@ -33,7 +33,7 @@ pub enum ExecuteMsg {
     /// # StoreObject
     /// StoreObject store an object to the bucket and make the sender the owner of the object.
     /// The object is referenced by the hash of its content and this value is returned.
-    /// If the object is already stored, an error is returned.
+    /// If the object is already stored, it is a no-op. It may be pinned though.
     ///
     /// The "pin" parameter specifies if the object should be pinned for the sender. In such case,
     /// the object cannot be removed (forget) from the storage.

--- a/docs/okp4-objectarium.md
+++ b/docs/okp4-objectarium.md
@@ -164,7 +164,7 @@ Execute messages
 
 ### ExecuteMsg::StoreObject
 
-StoreObject store an object to the bucket and make the sender the owner of the object. The object is referenced by the hash of its content and this value is returned. If the object is already stored, an error is returned.
+StoreObject store an object to the bucket and make the sender the owner of the object. The object is referenced by the hash of its content and this value is returned. If the object is already stored, it is a no-op. It may be pinned though.
 
 The "pin" parameter specifies if the object should be pinned for the sender. In such case, the object cannot be removed (forget) from the storage.
 
@@ -511,4 +511,4 @@ A string containing a 128-bit integer in decimal representation.
 
 ---
 
-_Rendered by [Fadroma](https://fadroma.tech) ([@fadroma/schema 1.1.0](https://www.npmjs.com/package/@fadroma/schema)) from `okp4-objectarium.json` (`8f8fd1b1c8982ddb`)_
+_Rendered by [Fadroma](https://fadroma.tech) ([@fadroma/schema 1.1.0](https://www.npmjs.com/package/@fadroma/schema)) from `okp4-objectarium.json` (`dbf16753cc3b0930`)_


### PR DESCRIPTION
This PR begins a behavioural change when storing an already existing object.

## Details

Instead of considering an already existing object a failure, we now act as a no-op, but still managing the pinning if required.

This will help instantiating `law-stone` smart contracts with the same code without failing.

This change is considered breaking.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit


- **New Features**
  - Enhanced object storage integrity by ensuring duplicates are not stored.
  - Refined object pinning process for better association.

- **Bug Fixes**
  - Adjusted error handling logic by removing unnecessary error types.

- **Documentation**
  - Updated `StoreObject` function behavior description and tooling information.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->